### PR TITLE
Fix version qualifier parsing problems

### DIFF
--- a/fr.obeo.releng.targetplatform.tests/src/fr/obeo/releng/targetplatform/tests/TestGrammar.xtend
+++ b/fr.obeo.releng.targetplatform.tests/src/fr/obeo/releng/targetplatform/tests/TestGrammar.xtend
@@ -41,6 +41,11 @@ class TestGrammar {
 			location "https://hudson.eclipse.org/hudson/view/Modeling/job/mdt-uml2-master/lastSuccessfulBuild/artifact/UML2.p2.repository/" {
 				org.eclipse.uml2.sdk.feature.group
 			}
+			
+			location "https://hudson.eclipse.org/hudson/view/Modeling/job/mdt-uml2-master/lastSuccessfulBuild/artifact/UML2.p2.repository/" {
+				org.eclipse.uml2.sdk.feature.group;version=10.1.1.20141228-2310-BUILD1 
+			}
+			
 		''')
 		assertTrue(targetPlatform.eResource.errors.join("\n"), targetPlatform.eResource.errors.empty)
 		val fisrtLocation = targetPlatform.locations.head

--- a/fr.obeo.releng.targetplatform/src/fr/obeo/releng/targetplatform/TargetPlatform.xtext
+++ b/fr.obeo.releng.targetplatform/src/fr/obeo/releng/targetplatform/TargetPlatform.xtext
@@ -46,7 +46,7 @@ IU:
 ;
 
 Version hidden():
-	INT ('.' INT ('.' INT ('.' (ID|INT))?)?)?
+	INT ('.' INT ('.' INT ('.' (ID|INT|QUALIFIER))?)?)?
 ;
 
 VersionRange hidden (WS):
@@ -55,3 +55,4 @@ VersionRange hidden (WS):
 
 terminal INT returns ecore::EInt: ('0'..'9')+;
 terminal ID: '^'?('a'..'z'|'A'..'Z'|'_') ('.'? ('a'..'z'|'A'..'Z'|'^'|'_'|'-'|'0'..'9'))*;
+terminal QUALIFIER: ('a'..'z'|'A'..'Z'|'_'|'-'|'0'..'9')*;


### PR DESCRIPTION
Fix amends grammar to understand bundle/feature versions used in eclipse
like 1.1.1.20141201-2310-BUILD1 which is now not valid.
It also adds location with bundle that uses vesion above in test
targetplatform definition.
