### PR TITLE
[#96] Fixing build problem on xtend-maven-plugin:2.14.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,6 +185,21 @@
               <artifactId>org.eclipse.equinox.common</artifactId>
               <version>3.10.0</version>
             </dependency>
+            <dependency>
+              <groupId>org.eclipse.jdt</groupId>
+              <artifactId>org.eclipse.jdt.core</artifactId>
+              <version>3.13.102</version>
+            </dependency>
+            <dependency>
+              <groupId>org.eclipse.jdt</groupId>
+              <artifactId>org.eclipse.jdt.debug</artifactId>
+              <version>3.10.1</version>
+            </dependency>
+            <dependency>
+              <groupId>org.eclipse.jdt</groupId>
+              <artifactId>org.eclipse.jdt.launching</artifactId>
+              <version>3.10.0</version>
+            </dependency>
           </dependencies>
         </plugin>
       </plugins>


### PR DESCRIPTION
- Use fix version numbers in the xtend-maven-plugin dependencies to
ensure that the build process succeeds.