### PR TITLE
[#65] Add hovering support over installabe units.

### DIFF
--- a/org.eclipse.cbi.targetplatform.ui/src/main/java/org/eclipse/cbi/targetplatform/ui/TargetPlatformUiModule.java
+++ b/org.eclipse.cbi.targetplatform.ui/src/main/java/org/eclipse/cbi/targetplatform/ui/TargetPlatformUiModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2014 Obeo and others.
+ * Copyright (c) 2012-2020 Obeo and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,10 +14,12 @@ import org.eclipse.cbi.targetplatform.ui.editor.autoedit.TargetPlatformAutoEditS
 import org.eclipse.cbi.targetplatform.ui.editor.syntaxcoloring.TargetPlatformHighlightingConfiguration;
 import org.eclipse.cbi.targetplatform.ui.editor.syntaxcoloring.TargetPlatformSemanticHighlightingCalculator;
 import org.eclipse.cbi.targetplatform.ui.editor.syntaxcoloring.TargetPlatformTokenToAttributeIdMapper;
+import org.eclipse.cbi.targetplatform.ui.hover.TargetPlatformHoverProvider;
 import org.eclipse.cbi.targetplatform.ui.hyperlinking.TargetPlatformHyperlinkHelper;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.eclipse.xtext.ide.editor.syntaxcoloring.ISemanticHighlightingCalculator;
 import org.eclipse.xtext.ui.editor.autoedit.AbstractEditStrategyProvider;
+import org.eclipse.xtext.ui.editor.hover.IEObjectHoverProvider;
 import org.eclipse.xtext.ui.editor.hyperlinking.IHyperlinkHelper;
 import org.eclipse.xtext.ui.editor.syntaxcoloring.AbstractAntlrTokenToAttributeIdMapper;
 import org.eclipse.xtext.ui.editor.syntaxcoloring.IHighlightingConfiguration;
@@ -50,5 +52,9 @@ public class TargetPlatformUiModule extends org.eclipse.cbi.targetplatform.ui.Ab
 
 	public Class<? extends IHyperlinkHelper> bindIHyperlinkHelper() {
 		return TargetPlatformHyperlinkHelper.class;
+	}
+
+	public Class<? extends IEObjectHoverProvider> bindIEObjectHoverProvider() {
+		return TargetPlatformHoverProvider.class;
 	}
 }

--- a/org.eclipse.cbi.targetplatform.ui/src/main/java/org/eclipse/cbi/targetplatform/ui/hover/TargetPlatformHoverProvider.xtend
+++ b/org.eclipse.cbi.targetplatform.ui/src/main/java/org/eclipse/cbi/targetplatform/ui/hover/TargetPlatformHoverProvider.xtend
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2020 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Tamas Miklossy (itemis AG) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.cbi.targetplatform.ui.hover
+
+import com.google.inject.Inject
+import java.net.URI
+import java.util.Set
+import org.eclipse.cbi.targetplatform.model.IU
+import org.eclipse.core.runtime.NullProgressMonitor
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.equinox.p2.core.IProvisioningAgent
+import org.eclipse.equinox.p2.metadata.IInstallableUnit
+import org.eclipse.equinox.p2.query.QueryUtil
+import org.eclipse.equinox.p2.repository.metadata.IMetadataRepositoryManager
+import org.eclipse.xtext.ui.editor.hover.html.DefaultEObjectHoverProvider
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+class TargetPlatformHoverProvider extends DefaultEObjectHoverProvider {
+
+	@Inject extension IProvisioningAgent
+
+	override protected getHoverInfoAsHtml(EObject o) {
+		return if (o instanceof IU) {
+			o.hoverInfo
+		} else {
+			super.getHoverInfoAsHtml(o)
+		}
+	}
+
+	private def String getHoverInfo(IU iu) {
+		val repositoryManager = IMetadataRepositoryManager.SERVICE_NAME.service as IMetadataRepositoryManager
+		val metadataRepository = repositoryManager.loadRepository(new URI(iu.location.uri), new NullProgressMonitor)
+		val idResults = metadataRepository.query(QueryUtil.createIUQuery(iu.ID), new NullProgressMonitor).toUnmodifiableSet
+		idResults.hoverInfo
+	}
+
+	private def String getHoverInfo(Set<IInstallableUnit> ius) {
+		if (ius.isEmpty) {
+			'''<b>No information available</b>'''
+		} else {
+			val name = ius.findFirst[!name.nullOrEmpty]?.name
+			val provider = ius.findFirst[!provider.nullOrEmpty]?.provider
+			val versions = ius.sortBy[version].reverse.map[version]
+			'''
+				«IF name !== null»<b>Name:</b> «name»<br>«ENDIF»
+				«IF provider !== null»<b>Provider:</b> «provider»<br>«ENDIF»
+				«IF versions.size == 1»
+					<b>Version:</b> «versions.head»
+				«ELSE»
+					<b>Versions:</b><br>
+					«FOR version : versions SEPARATOR "<br>"»
+						«version»
+					«ENDFOR»
+				«ENDIF»
+			'''
+		}
+	}
+
+	private def getName(IInstallableUnit it) {
+		getProperty(IInstallableUnit.PROP_NAME, null)
+	}
+
+	private def getProvider(IInstallableUnit it) {
+		getProperty(IInstallableUnit.PROP_PROVIDER, null)
+	}
+}


### PR DESCRIPTION
- Hovering over an insallable unit shows its properties like the name,
provider, and version.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>

Closes #65