### PR TITLE
[#106] Add hyperlink support to the include declarations.

### DIFF
--- a/org.eclipse.cbi.targetplatform.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.cbi.targetplatform.ui.tests/META-INF/MANIFEST.MF
@@ -21,7 +21,11 @@ Require-Bundle: org.eclipse.cbi.targetplatform,
  org.eclipse.ui.workbench;resolution:=optional,
  org.eclipse.xtext.ui.shared,
  org.eclipse.equinox.p2.metadata;bundle-version="2.2.0",
- org.eclipse.equinox.p2.core;bundle-version="2.3.0"
+ org.eclipse.equinox.p2.core;bundle-version="2.3.0",
+ org.eclipse.jdt.core,
+ org.eclipse.xtext.common.types.ui,
+ org.eclipse.xtext.ui.testing,
+ org.eclipse.equinox.event
 Import-Package: org.hamcrest.core,
  org.junit.runner.manipulation;version="4.5.0",
  org.junit.runner.notification;version="4.5.0",

--- a/org.eclipse.cbi.targetplatform.ui.tests/src/main/java/org/eclipse/cbi/targetplatform/ui/tests/AbstractHyperlinkingTest.xtend
+++ b/org.eclipse.cbi.targetplatform.ui.tests/src/main/java/org/eclipse/cbi/targetplatform/ui/tests/AbstractHyperlinkingTest.xtend
@@ -1,0 +1,179 @@
+/*******************************************************************************
+ * Copyright (c) 2020 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Tamas Miklossy (itemis AG) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.cbi.targetplatform.ui.tests
+
+import com.google.inject.Inject
+import org.eclipse.core.resources.IFile
+import org.eclipse.core.resources.IProject
+import org.eclipse.core.runtime.NullProgressMonitor
+import org.eclipse.jdt.core.IType
+import org.eclipse.jface.text.IRegion
+import org.eclipse.jface.text.Region
+import org.eclipse.jface.text.hyperlink.IHyperlink
+import org.eclipse.xtext.common.types.xtext.ui.JdtHyperlink
+import org.eclipse.xtext.naming.IQualifiedNameProvider
+import org.eclipse.xtext.resource.FileExtensionProvider
+import org.eclipse.xtext.resource.XtextResource
+import org.eclipse.xtext.ui.XtextProjectHelper
+import org.eclipse.xtext.ui.editor.XtextEditor
+import org.eclipse.xtext.ui.editor.hyperlinking.IHyperlinkHelper
+import org.eclipse.xtext.ui.editor.hyperlinking.XtextHyperlink
+import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil
+import org.eclipse.xtext.ui.refactoring.ui.SyncUtil
+import org.eclipse.xtext.ui.resource.IResourceSetProvider
+import org.eclipse.xtext.ui.testing.AbstractEditorTest
+import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil
+import org.eclipse.xtext.util.concurrent.IUnitOfWork
+
+import static extension org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil.addNature
+
+/**
+ * @author miklossy - Initial contribution and API
+ * 
+ * This class is a copy of the org.eclipse.xtext.ui.testing.AbstractHyperlinkingTest class
+ * available from Xtext version 2.17 (Eclipse 2019-03).
+ *
+ * TODO: remove this class as soon as updating to Xtext version 2.17 or above.
+ */
+abstract class AbstractHyperlinkingTest extends AbstractEditorTest {
+
+	@Inject protected extension IHyperlinkHelper
+	@Inject protected extension FileExtensionProvider
+	@Inject protected extension IQualifiedNameProvider
+	@Inject protected extension SyncUtil
+
+	@Inject protected IResourceSetProvider resourceSetProvider
+	
+	protected IProject project
+
+	// position marker
+	protected val c = '''<|>'''
+
+	/**
+	 * Tests that the user can navigate to the target element in a DSL text when activating the hyperlink on a certain region.
+	 * 
+	 * @param it
+	 *            The DSL text. The text must contain the {@link #c} special symbols twice indicating the beginning and the end of the
+	 *            region wehre the hyperlink navigation gets activated.
+	 * @param hyperlinkTarget
+	 *            The fully qualified name of the expected target element.
+	 */
+	def void hasHyperlinkTo(CharSequence it, String hyperlinkTarget) {
+		hasHyperlinkTo(hyperlinkRegion, hyperlinkTarget)
+	}
+
+	/**
+	 * Tests that the user can navigate to the target element in a DSL text when activating the hyperlink on a certain region.
+	 * 
+	 * @param it The initial DSL text.
+	 * @param hyperlinkRegion The region where the hyperlink navigation gets activated.
+	 * @param hyperlinkTarget The fully qualified name of the expected target element.
+	 */
+	def void hasHyperlinkTo(CharSequence it, IRegion hyperlinkRegion, String hyperlinkTarget) {
+		// given
+		dslFile.
+		// when
+		hyperlinkingOn(hyperlinkRegion.offset).
+		// then
+		hyperlinkIsOffered(hyperlinkRegion, hyperlinkTarget)
+	}
+
+	protected def IFile dslFile(CharSequence text) {
+		val content = text.toString.replace(c, "")
+		val file = IResourcesSetupUtil.createFile(projectName, fileName, fileExtension, content.toString)
+
+		/*
+		 * TODO: find a better (with good performance) solution
+		 * to set the Xtext nature on the test project.
+		 */
+		val project = file.project
+		if(!project.hasNature(XtextProjectHelper.NATURE_ID)) {
+			project.addNature(XtextProjectHelper.NATURE_ID)
+		}
+
+		file
+	}
+
+	protected def IHyperlink[] hyperlinkingOn(IFile dslFile, int offset) {
+		val editor = dslFile.openInEditor
+		val document = XtextDocumentUtil.get(editor.internalSourceViewer)
+		val resource = document.readOnly(new IUnitOfWork<XtextResource, XtextResource>(){
+
+			override exec(XtextResource state) {
+				state
+			}
+			
+		})
+
+		resource.createHyperlinksByOffset(offset, true)
+	}
+
+	protected def XtextEditor openInEditor(IFile dslFile) {
+		/*
+		 * wait for the cross-reference resolution
+		 */
+		waitForBuild(new NullProgressMonitor)
+		dslFile.openEditor
+	}
+
+	protected def void hyperlinkIsOffered(IHyperlink[] hyperlinks, IRegion expectedRegion, String expectedHyperlinkTarget) {
+		assertNotNull("No hyperlinks found!", hyperlinks)
+		assertEquals(1, hyperlinks.length)
+		val hyperlink = hyperlinks.head
+		
+		expectedRegion.assertEquals(hyperlink.hyperlinkRegion)
+		expectedHyperlinkTarget.assertEquals(hyperlink.target)
+	}
+
+	protected def dispatch String target(JdtHyperlink hyperlink) {
+		val javaElement = hyperlink.javaElement
+		assertTrue(javaElement instanceof IType)
+		(javaElement as IType).fullyQualifiedName
+	}
+
+	protected def dispatch String target(XtextHyperlink hyperlink) {
+		val resourceSet = resourceSetProvider.get(project)
+		val eObject = resourceSet.getEObject(hyperlink.URI, true)
+		eObject.fullyQualifiedName.toString
+	}
+
+	protected def dispatch String target(IHyperlink hyperlink) {
+		fail("Unsupported hyperlink " + hyperlink.class)
+		null
+	}
+
+	protected def String getProjectName() {
+		"HyperlinkingTestProject"
+	}
+
+	protected def String getFileName() {
+		"hyperlinking"
+	}
+
+	protected def String getFileExtension() {
+		primaryFileExtension
+	}
+
+	protected def IRegion hyperlinkRegion(CharSequence input) {
+		val text = input.toString
+		val first = text.indexOf(c)
+		if (first==-1) {
+			fail('''Can't locate the first position symbol '�c�' in the input text''')
+		}
+		val second = text.lastIndexOf(c)
+		if (first==second) {
+			fail('''Can't locate the second position symbol '�c�' in the input text''')
+		}
+		val offset = first
+		val length = second - first - c.length
+		new Region(offset, length)
+	}
+}

--- a/org.eclipse.cbi.targetplatform.ui.tests/src/main/java/org/eclipse/cbi/targetplatform/ui/tests/AllUITests.java
+++ b/org.eclipse.cbi.targetplatform.ui.tests/src/main/java/org/eclipse/cbi/targetplatform/ui/tests/AllUITests.java
@@ -7,6 +7,7 @@ import org.junit.runners.Suite.SuiteClasses;
 @RunWith(Suite.class)
 @SuiteClasses({
 	TestContentAssist.class,
+	TargetPlatformHyperlinkingTest.class
 })
 public class AllUITests {
 

--- a/org.eclipse.cbi.targetplatform.ui.tests/src/main/java/org/eclipse/cbi/targetplatform/ui/tests/TargetPlatformHyperlinkingTest.xtend
+++ b/org.eclipse.cbi.targetplatform.ui.tests/src/main/java/org/eclipse/cbi/targetplatform/ui/tests/TargetPlatformHyperlinkingTest.xtend
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2020 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Tamas Miklossy (itemis AG) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.cbi.targetplatform.ui.tests
+
+import com.google.inject.Inject
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.ui.editor.XtextEditorInfo
+import org.eclipse.xtext.ui.editor.hyperlinking.XtextHyperlink
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import static extension org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil.createFile
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner)
+@InjectWith(TargetPlatformUiInjectorProvider)
+class TargetPlatformHyperlinkingTest extends AbstractHyperlinkingTest {
+
+	@Inject XtextEditorInfo editorInfo
+
+	@Test def hyperlink_on_include_declaration_on_same_level() {
+
+		createEmptyFile(projectName + "/4.4-luna.tpd")
+
+		'''
+			target "Test Target Platform"
+			include "«c»4.4-luna.tpd«c»"
+		'''.hasHyperlinkTo("platform:/resource/HyperlinkingTestProject/4.4-luna.tpd")
+	}
+
+	@Test def hyperlink_on_include_declaration_one_level_below() {
+
+		createEmptyFile(projectName + "/testing/4.4-luna.tpd")
+
+		'''
+			target "Test Target Platform"
+			include "«c»testing/4.4-luna.tpd«c»"
+		'''.hasHyperlinkTo("platform:/resource/HyperlinkingTestProject/testing/4.4-luna.tpd")
+	}
+
+	@Test def hyperlink_on_include_declaration_one_level_above() {
+
+		createEmptyFile("inc/xtext-target.tpd")
+
+		'''
+			target "Test Target Platform"
+			include "«c»../inc/xtext-target.tpd«c»"
+		'''.hasHyperlinkTo("platform:/resource/inc/xtext-target.tpd")
+	}
+
+	private def createEmptyFile(String workspaceRelativePath) {
+		workspaceRelativePath.createFile("")
+	}
+
+	override protected dispatch target(XtextHyperlink hyperlink) {
+		hyperlink.URI.toString
+	}
+
+	override protected getEditorId() {
+		editorInfo.editorId
+	}
+
+}

--- a/org.eclipse.cbi.targetplatform.ui/src/main/java/org/eclipse/cbi/targetplatform/ui/TargetPlatformUiModule.java
+++ b/org.eclipse.cbi.targetplatform.ui/src/main/java/org/eclipse/cbi/targetplatform/ui/TargetPlatformUiModule.java
@@ -10,16 +10,17 @@
  *******************************************************************************/
 package org.eclipse.cbi.targetplatform.ui;
 
-import org.eclipse.ui.plugin.AbstractUIPlugin;
-import org.eclipse.xtext.ui.editor.autoedit.AbstractEditStrategyProvider;
-import org.eclipse.xtext.ui.editor.syntaxcoloring.AbstractAntlrTokenToAttributeIdMapper;
-import org.eclipse.xtext.ui.editor.syntaxcoloring.IHighlightingConfiguration;
-import org.eclipse.xtext.ide.editor.syntaxcoloring.ISemanticHighlightingCalculator;
-
 import org.eclipse.cbi.targetplatform.ui.editor.autoedit.TargetPlatformAutoEditStrategyProvider;
 import org.eclipse.cbi.targetplatform.ui.editor.syntaxcoloring.TargetPlatformHighlightingConfiguration;
 import org.eclipse.cbi.targetplatform.ui.editor.syntaxcoloring.TargetPlatformSemanticHighlightingCalculator;
 import org.eclipse.cbi.targetplatform.ui.editor.syntaxcoloring.TargetPlatformTokenToAttributeIdMapper;
+import org.eclipse.cbi.targetplatform.ui.hyperlinking.TargetPlatformHyperlinkHelper;
+import org.eclipse.ui.plugin.AbstractUIPlugin;
+import org.eclipse.xtext.ide.editor.syntaxcoloring.ISemanticHighlightingCalculator;
+import org.eclipse.xtext.ui.editor.autoedit.AbstractEditStrategyProvider;
+import org.eclipse.xtext.ui.editor.hyperlinking.IHyperlinkHelper;
+import org.eclipse.xtext.ui.editor.syntaxcoloring.AbstractAntlrTokenToAttributeIdMapper;
+import org.eclipse.xtext.ui.editor.syntaxcoloring.IHighlightingConfiguration;
 
 /**
  * Use this class to register components to be used within the IDE.
@@ -45,5 +46,9 @@ public class TargetPlatformUiModule extends org.eclipse.cbi.targetplatform.ui.Ab
 	
 	public Class<? extends AbstractAntlrTokenToAttributeIdMapper> bindAbstractAntlrTokenToAttributeIdMapper() {
 		return TargetPlatformTokenToAttributeIdMapper.class;
+	}
+
+	public Class<? extends IHyperlinkHelper> bindIHyperlinkHelper() {
+		return TargetPlatformHyperlinkHelper.class;
 	}
 }

--- a/org.eclipse.cbi.targetplatform.ui/src/main/java/org/eclipse/cbi/targetplatform/ui/hyperlinking/TargetPlatformHyperlinkHelper.xtend
+++ b/org.eclipse.cbi.targetplatform.ui/src/main/java/org/eclipse/cbi/targetplatform/ui/hyperlinking/TargetPlatformHyperlinkHelper.xtend
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2020 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Tamas Miklossy (itemis AG) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.cbi.targetplatform.ui.hyperlinking
+
+import org.eclipse.cbi.targetplatform.model.IncludeDeclaration
+import org.eclipse.jface.text.Region
+import org.eclipse.xtext.resource.XtextResource
+import org.eclipse.xtext.ui.editor.hyperlinking.HyperlinkHelper
+import org.eclipse.xtext.ui.editor.hyperlinking.IHyperlinkAcceptor
+
+import static org.eclipse.cbi.targetplatform.model.TargetPlatformPackage.Literals.INCLUDE_DECLARATION__IMPORT_URI
+
+import static extension org.eclipse.emf.common.util.URI.createURI
+import static extension org.eclipse.xtext.nodemodel.util.NodeModelUtils.findNodesForFeature
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+class TargetPlatformHyperlinkHelper extends HyperlinkHelper {
+
+	override createHyperlinksByOffset(XtextResource resource, int offset, IHyperlinkAcceptor acceptor) {
+		super.createHyperlinksByOffset(resource, offset, acceptor)
+
+		val it = getEObjectAtOffsetHelper.resolveElementAt(resource, offset)
+		if (it instanceof IncludeDeclaration) {
+			val hyperlink = hyperlinkProvider.get
+
+			hyperlink.hyperlinkRegion = hyperlinkRegion
+			hyperlink.URI = importURI.createURI.resolve(resource.URI)
+
+			acceptor.accept(hyperlink)
+		}
+	}
+
+	private def getHyperlinkRegion(IncludeDeclaration includeDeclaration) {
+		val nodes = includeDeclaration.findNodesForFeature(INCLUDE_DECLARATION__IMPORT_URI)
+
+		if (nodes.size != 1) {
+			throw new IllegalStateException("Exact 1 node is expected for the feature, but got " + nodes.size + " node(s).")
+		}
+
+		val it = nodes.head.textRegion
+
+		// trimming the quotes
+		new Region(offset + 1, length - 2)
+	}
+
+}


### PR DESCRIPTION
- Add customized TargetPlatformHyperlinkHelper to detect hyperlinks on
include declarations.
- Add corresponding TargetPlatformHyperlinkHelper test cases.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>

Closes https://github.com/eclipse-cbi/targetplatform-dsl/issues/106