### PR TITLE
[#127] Generating maven locations from included files

### DIFF
--- a/org.eclipse.cbi.targetplatform.tests/src/main/java/org/eclipse/cbi/targetplatform/tests/TestTargetConversion.xtend
+++ b/org.eclipse.cbi.targetplatform.tests/src/main/java/org/eclipse/cbi/targetplatform/tests/TestTargetConversion.xtend
@@ -18,10 +18,11 @@ import com.google.inject.Provider
 import org.eclipse.cbi.targetplatform.model.TargetPlatform
 import org.eclipse.cbi.targetplatform.resolved.ResolvedTargetPlatform
 import org.eclipse.cbi.targetplatform.tests.stubs.p2.IQueryResultProvider
-import org.eclipse.cbi.targetplatform.tests.stubs.p2.MetadataRepositoryManagerStub
 import org.eclipse.cbi.targetplatform.tests.stubs.p2.IUStub
+import org.eclipse.cbi.targetplatform.tests.stubs.p2.MetadataRepositoryManagerStub
 import org.eclipse.cbi.targetplatform.tests.util.CustomTargetPlatformInjectorProvider
 import org.eclipse.cbi.targetplatform.util.LocationIndexBuilder
+import org.eclipse.cbi.targetplatform.util.MavenLocationIndexBuilder
 import org.eclipse.core.runtime.IProgressMonitor
 import org.eclipse.core.runtime.NullProgressMonitor
 import org.eclipse.core.runtime.OperationCanceledException
@@ -52,6 +53,9 @@ class TestTargetConversion {
 	@Inject
 	LocationIndexBuilder indexBuilder;
 	
+	@Inject
+	MavenLocationIndexBuilder mavenIndexBuilder;
+	
 	@Test
 	def testBasicBundle() {
 		val targetPlatform = parser.parse('''
@@ -63,7 +67,7 @@ class TestTargetConversion {
 			}
 			''')
 		
-		val targetDef = ResolvedTargetPlatform.create(targetPlatform, indexBuilder);
+		val targetDef = ResolvedTargetPlatform.create(targetPlatform, indexBuilder, mavenIndexBuilder);
 		targetDef.resolve(new MetadataRepositoryManagerStub(new IQueryResultProvider<IInstallableUnit>() {
 			override listIUs(java.net.URI location) {
 				if ("http://download.eclipse.org/tools/orbit/downloads/drops/R20130517111416/repository/".equals(location.toString)) {
@@ -102,7 +106,7 @@ class TestTargetConversion {
 			}
 			''')
 		
-		val resolvedTargetPlatform = ResolvedTargetPlatform.create(targetPlatform, indexBuilder);
+		val resolvedTargetPlatform = ResolvedTargetPlatform.create(targetPlatform, indexBuilder, mavenIndexBuilder);
 		val d = resolvedTargetPlatform.resolve(new MetadataRepositoryManagerStub(null) {
 			override loadRepository(java.net.URI location, IProgressMonitor monitor) throws ProvisionException, OperationCanceledException {
 				if ("unknownHost".equals(location.toString)) {
@@ -130,7 +134,7 @@ class TestTargetConversion {
 			}
 		''')
 
-		val targetDef = ResolvedTargetPlatform.create(targetPlatform, indexBuilder);
+		val targetDef = ResolvedTargetPlatform.create(targetPlatform, indexBuilder, mavenIndexBuilder);
 		targetDef.resolve(new MetadataRepositoryManagerStub(new IQueryResultProvider<IInstallableUnit>() {
 			override listIUs(java.net.URI location) {
 				if ("http://download.eclipse.org/modeling/emf/compare/updates/releases/2.1/R201310031412/".equals(location.toString)) {
@@ -170,7 +174,7 @@ class TestTargetConversion {
 			}
 		''', URI.createURI("tmp:/tp2.tpd"), resourceSet)
 		
-		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder);
+		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 		targetDef.resolve(new MetadataRepositoryManagerStub(new IQueryResultProvider<IInstallableUnit>() {
 			override listIUs(java.net.URI location) {
 				if ("http://download.eclipse.org/modeling/emf/compare/updates/releases/2.1/R201310031412/".equals(location.toString)) {
@@ -217,7 +221,7 @@ class TestTargetConversion {
 			}
 		''', URI.createURI("tmp:/tp2.tpd"), resourceSet)
 		
-		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder);
+		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 		targetDef.resolve(new MetadataRepositoryManagerStub(new IQueryResultProvider<IInstallableUnit>() {
 			override listIUs(java.net.URI location) {
 				if ("http://download.eclipse.org/modeling/emf/compare/updates/releases/2.1/R201310031412/".equals(location.toString)) {
@@ -259,7 +263,7 @@ class TestTargetConversion {
 			}
 		''', URI.createURI("tmp:/tp2.tpd"), resourceSet)
 		
-		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder);
+		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 		targetDef.resolve(new MetadataRepositoryManagerStub(new IQueryResultProvider<IInstallableUnit>() {
 			override listIUs(java.net.URI location) {
 				if ("http://download.eclipse.org/modeling/emf/compare/updates/releases/2.1/R201310031412/".equals(location.toString)) {
@@ -297,7 +301,7 @@ class TestTargetConversion {
 			}
 		''', URI.createURI("tmp:/tp1.tpd"), resourceSet)
 
-		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder);
+		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 		targetDef.resolve(new MetadataRepositoryManagerStub(new IQueryResultProvider<IInstallableUnit>() {
 			override listIUs(java.net.URI location) {
 				if ("http://download.eclipse.org/modeling/emf/compare/updates/releases/2.1/R201310031412/".equals(location.toString)) {
@@ -338,7 +342,7 @@ class TestTargetConversion {
 			}
 		''', URI.createURI("tmp:/tp2.tpd"), resourceSet)
 
-		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder);
+		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 		targetDef.resolve(new MetadataRepositoryManagerStub(new IQueryResultProvider<IInstallableUnit>() {
 			override listIUs(java.net.URI location) {
 				if ("http://download.eclipse.org/tools/orbit/downloads/drops/R20130517111416/repository/".equals(location.toString)) {
@@ -384,7 +388,7 @@ class TestTargetConversion {
 			}
 		''', URI.createURI("tmp:/tp3.tpd"), resourceSet)
 		
-		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder);
+		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 		targetDef.resolve(new MetadataRepositoryManagerStub(new IQueryResultProvider<IInstallableUnit>() {
 			override listIUs(java.net.URI location) {
 				if ("http://download.eclipse.org/tools/orbit/downloads/drops/R20130517111416/repository/".equals(location.toString)) {
@@ -430,7 +434,7 @@ class TestTargetConversion {
 			}
 		''', URI.createURI("tmp:/tp3.tpd"), resourceSet)
 		
-		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder);
+		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 		targetDef.resolve(new MetadataRepositoryManagerStub(new IQueryResultProvider<IInstallableUnit>() {
 			override listIUs(java.net.URI location) {
 				if ("http://download.eclipse.org/tools/orbit/downloads/drops/R20130517111416/repository/".equals(location.toString)) {
@@ -476,7 +480,7 @@ class TestTargetConversion {
 			}
 		''', URI.createURI("tmp:/tp3.tpd"), resourceSet)
 		
-		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder);
+		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 		targetDef.resolve(new MetadataRepositoryManagerStub(new IQueryResultProvider<IInstallableUnit>() {
 			override listIUs(java.net.URI location) {
 				if ("http://download.eclipse.org/tools/orbit/downloads/drops/R20130517111416/repository/".equals(location.toString)) {
@@ -522,7 +526,7 @@ class TestTargetConversion {
 			}
 		''', URI.createURI("tmp:/tp3.tpd"), resourceSet)
 		
-		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder);
+		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 		targetDef.resolve(new MetadataRepositoryManagerStub(new IQueryResultProvider<IInstallableUnit>() {
 			override listIUs(java.net.URI location) {
 				if ("http://download.eclipse.org/tools/orbit/downloads/drops/R20130517111416/repository/".equals(location.toString)) {
@@ -561,7 +565,7 @@ class TestTargetConversion {
 			}
 		''', URI.createURI("tmp:/tp1.tpd"), resourceSet)
 		
-		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder);
+		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 		targetDef.resolve(new MetadataRepositoryManagerStub(new IQueryResultProvider<IInstallableUnit>() {
 			override listIUs(java.net.URI location) {
 				if ("http://download.eclipse.org/tools/orbit/downloads/drops/R20130517111416/repository/".equals(location.toString)) {
@@ -600,7 +604,7 @@ class TestTargetConversion {
 			}
 		''', URI.createURI("tmp:/tp1.tpd"), resourceSet)
 		
-		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder);
+		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 		targetDef.resolve(new MetadataRepositoryManagerStub(new IQueryResultProvider<IInstallableUnit>() {
 			override listIUs(java.net.URI location) {
 				if ("http://download.eclipse.org/tools/orbit/downloads/drops/R20130517111416/repository/".equals(location.toString)) {
@@ -637,7 +641,7 @@ class TestTargetConversion {
 			}
 		''', URI.createURI("tmp:/tp1.tpd"), resourceSet)
 		
-		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder);
+		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 		targetDef.resolve(new MetadataRepositoryManagerStub(new IQueryResultProvider<IInstallableUnit>() {
 			override listIUs(java.net.URI location) {
 				if ("http://download.eclipse.org/tools/orbit/downloads/drops/R20130517111416/repository/".equals(location.toString)) {
@@ -674,7 +678,7 @@ class TestTargetConversion {
 			}
 		''', URI.createURI("tmp:/tp1.tpd"), resourceSet)
 		
-		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder);
+		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 		targetDef.resolve(new MetadataRepositoryManagerStub(new IQueryResultProvider<IInstallableUnit>() {
 			override listIUs(java.net.URI location) {
 				if ("http://download.eclipse.org/tools/orbit/downloads/drops/R20130517111416/repository/".equals(location.toString)) {
@@ -709,7 +713,7 @@ class TestTargetConversion {
 			}
 		''')
 		
-		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder);
+		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 		targetDef.resolve(new MetadataRepositoryManagerStub(new IQueryResultProvider<IInstallableUnit>() {
 			override listIUs(java.net.URI location) {
 				if ("http://download.eclipse.org/tools/orbit/downloads/drops/R20130517111416/repository/".equals(location.toString)) {
@@ -742,7 +746,7 @@ class TestTargetConversion {
 			}
 		''')
 		
-		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder);
+		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 		targetDef.resolve(new MetadataRepositoryManagerStub(new IQueryResultProvider<IInstallableUnit>() {
 			override listIUs(java.net.URI location) {
 				if ("http://download.eclipse.org/tools/orbit/downloads/drops/R20130517111416/repository/".equals(location.toString)) {
@@ -775,7 +779,7 @@ class TestTargetConversion {
 			}
 		''')
 		
-		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder);
+		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 		targetDef.resolve(new MetadataRepositoryManagerStub(new IQueryResultProvider<IInstallableUnit>() {
 			override listIUs(java.net.URI location) {
 				if ("http://download.eclipse.org/modeling/emf/compare/updates/releases/2.1/R201310031412/".equals(location.toString)) {
@@ -808,7 +812,7 @@ class TestTargetConversion {
 			}
 		''')
 		
-		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder);
+		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 		targetDef.resolve(new MetadataRepositoryManagerStub(new IQueryResultProvider<IInstallableUnit>() {
 			override listIUs(java.net.URI location) {
 				if ("http://download.eclipse.org/modeling/emf/compare/updates/releases/2.1/R201310031412/".equals(location.toString)) {
@@ -841,7 +845,7 @@ class TestTargetConversion {
 			location "http://download.eclipse.org/tools/orbit/downloads/drops/R20130517111416/repository/"
 		''')
 		
-		val targetDef = ResolvedTargetPlatform.create(o, indexBuilder);
+		val targetDef = ResolvedTargetPlatform.create(o, indexBuilder, mavenIndexBuilder);
 		targetDef.resolve(new MetadataRepositoryManagerStub(new IQueryResultProvider<IInstallableUnit>() {
 			override listIUs(java.net.URI location) {
 				return emptyList
@@ -871,7 +875,7 @@ class TestTargetConversion {
 			location "http://download.eclipse.org/sirius/updates/releases/0.9.0/kepler"
 		''', URI.createURI("tmp:/tp2.tpd"), resourceSet)
 		
-		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder);
+		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 		targetDef.resolve(new MetadataRepositoryManagerStub(new IQueryResultProvider<IInstallableUnit>() {
 			override listIUs(java.net.URI location) {
 				return emptyList
@@ -907,7 +911,7 @@ class TestTargetConversion {
 			location "http://download.eclipse.org/sirius/updates/releases/0.9.0/kepler"
 		''', URI.createURI("tmp:/tp3.tpd"), resourceSet)
 		
-		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder);
+		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 		targetDef.resolve(new MetadataRepositoryManagerStub(new IQueryResultProvider<IInstallableUnit>() {
 			override listIUs(java.net.URI location) {
 				return emptyList
@@ -943,7 +947,7 @@ class TestTargetConversion {
 			location "http://download.eclipse.org/sirius/updates/releases/0.9.0/kepler"
 		''', URI.createURI("tmp:/tp3.tpd"), resourceSet)
 		
-		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder);
+		val targetDef = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 		targetDef.resolve(new MetadataRepositoryManagerStub(new IQueryResultProvider<IInstallableUnit>() {
 			override listIUs(java.net.URI location) {
 				return emptyList
@@ -977,7 +981,7 @@ class TestTargetConversion {
 			}
 		''')
 		
-		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp, indexBuilder);
+		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp, indexBuilder, mavenIndexBuilder);
 		val d = resolvedTargetPlatform.resolve(new MetadataRepositoryManagerStub(new IQueryResultProvider<IInstallableUnit>() {
 			override listIUs(java.net.URI location) {
 				if ("http://download.eclipse.org/egit/updates-3.3".equals(location.toString)) {

--- a/org.eclipse.cbi.targetplatform.tests/src/main/java/org/eclipse/cbi/targetplatform/tests/TestTargetGeneration.xtend
+++ b/org.eclipse.cbi.targetplatform.tests/src/main/java/org/eclipse/cbi/targetplatform/tests/TestTargetGeneration.xtend
@@ -1,13 +1,13 @@
 /**
  * Copyright (c) 2012-2014 Obeo and others.
- *
+ * 
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-2.0/
- *
+ * 
  * SPDX-License-Identifier: EPL-2.0
- *
+ * 
  * Contributors:
  *     Mikael Barbero (Obeo) - initial API and implementation
  */
@@ -20,10 +20,11 @@ import org.eclipse.cbi.targetplatform.model.TargetPlatform
 import org.eclipse.cbi.targetplatform.pde.TargetDefinitionGenerator
 import org.eclipse.cbi.targetplatform.resolved.ResolvedTargetPlatform
 import org.eclipse.cbi.targetplatform.tests.stubs.p2.IQueryResultProvider
-import org.eclipse.cbi.targetplatform.tests.stubs.p2.MetadataRepositoryManagerStub
 import org.eclipse.cbi.targetplatform.tests.stubs.p2.IUStub
+import org.eclipse.cbi.targetplatform.tests.stubs.p2.MetadataRepositoryManagerStub
 import org.eclipse.cbi.targetplatform.tests.util.CustomTargetPlatformInjectorProvider
 import org.eclipse.cbi.targetplatform.util.LocationIndexBuilder
+import org.eclipse.cbi.targetplatform.util.MavenLocationIndexBuilder
 import org.eclipse.core.runtime.NullProgressMonitor
 import org.eclipse.equinox.p2.metadata.IInstallableUnit
 import org.eclipse.equinox.p2.metadata.Version
@@ -38,39 +39,41 @@ import static org.junit.Assert.*
 @InjectWith(typeof(CustomTargetPlatformInjectorProvider))
 @RunWith(typeof(XtextRunner))
 class TestTargetGeneration {
-	
-	
+
 	@Inject
 	ParseHelper<TargetPlatform> parser
-	
+
 	@Inject
 	LocationIndexBuilder indexBuilder;
-	
+
+	@Inject
+	MavenLocationIndexBuilder mavenIndexBuilder;
+
 	@Test(expected=typeof(IllegalArgumentException))
 	def void testEmptyTP() {
 		val tp1 = parser.parse('''
 		''')
-		ResolvedTargetPlatform.create(tp1, indexBuilder);
+		ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 	}
-	
+
 	@Test
 	def void testNamedTP() {
 		val tp1 = parser.parse('''
 			target "TP1"
 		''')
-		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder);
-		
+		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
+
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
 		assertEquals('''
-		<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-		<?pde?>
-		<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-		<target name="TP1" sequenceNumber="1">
-		</target>
+			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+			<?pde?>
+			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
+			<target name="TP1" sequenceNumber="1">
+			</target>
 		'''.toString, content)
 	}
-	
+
 	@Test
 	def void testSingleLocationSingleIU() {
 		val tp1 = parser.parse('''
@@ -80,34 +83,34 @@ class TestTargetGeneration {
 				an.iu
 			}
 		''')
-		
-		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder);
+
+		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 		resolvedTargetPlatform.resolve(new MetadataRepositoryManagerStub(new IQueryResultProvider<IInstallableUnit>() {
 			override listIUs(URI location) {
 				if ("http://location.org/p2".equals(location.toString)) {
 					newImmutableList(
-						IUStub.createBundle("an.iu", Version.createOSGi(1,0,0, "thequalifier"))
+						IUStub.createBundle("an.iu", Version.createOSGi(1, 0, 0, "thequalifier"))
 					)
 				} else {
 					return emptyList
 				}
 			}
 		}), new NullProgressMonitor());
-		
+
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
 		assertEquals('''
-		<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-		<?pde?>
-		<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-		<target name="TP1" sequenceNumber="1">
-		  <locations>
-		    <location includeMode="slicer" includeAllPlatforms="false" includeSource="false" includeConfigurePhase="false" type="InstallableUnit">
-		      <unit id="an.iu" version="1.0.0.thequalifier"/>
-		      <repository location="http://location.org/p2"/>
-		    </location>
-		  </locations>
-		</target>
+			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+			<?pde?>
+			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
+			<target name="TP1" sequenceNumber="1">
+			  <locations>
+			    <location includeMode="slicer" includeAllPlatforms="false" includeSource="false" includeConfigurePhase="false" type="InstallableUnit">
+			      <unit id="an.iu" version="1.0.0.thequalifier"/>
+			      <repository location="http://location.org/p2"/>
+			    </location>
+			  </locations>
+			</target>
 		'''.toString, content)
 	}
 
@@ -121,42 +124,42 @@ class TestTargetGeneration {
 				an.iu2;version=[1.2.0,2.0.0)
 			}
 		''')
-		
-		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder);
+
+		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 		resolvedTargetPlatform.resolve(new MetadataRepositoryManagerStub(new IQueryResultProvider<IInstallableUnit>() {
 			override listIUs(URI location) {
 				var List<IInstallableUnit> ret
 				if ("http://location.org/p2".equals(location.toString)) {
-						ret = newImmutableList(
-							IUStub.createBundle("an.iu", Version.createOSGi(1,0,0, "thequalifier")), 
-							IUStub.createBundle("an.iu2", Version.createOSGi(1,3,74, null))
-						)
+					ret = newImmutableList(
+						IUStub.createBundle("an.iu", Version.createOSGi(1, 0, 0, "thequalifier")),
+						IUStub.createBundle("an.iu2", Version.createOSGi(1, 3, 74, null))
+					)
 				} else {
 					ret = emptyList
 				}
 				return ret;
 			}
-			
+
 		}), new NullProgressMonitor());
-		
+
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
 		assertEquals('''
-		<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-		<?pde?>
-		<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-		<target name="TP1" sequenceNumber="1">
-		  <locations>
-		    <location includeMode="slicer" includeAllPlatforms="false" includeSource="false" includeConfigurePhase="false" type="InstallableUnit">
-		      <unit id="an.iu" version="1.0.0.thequalifier"/>
-		      <unit id="an.iu2" version="1.3.74"/>
-		      <repository location="http://location.org/p2"/>
-		    </location>
-		  </locations>
-		</target>
+			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+			<?pde?>
+			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
+			<target name="TP1" sequenceNumber="1">
+			  <locations>
+			    <location includeMode="slicer" includeAllPlatforms="false" includeSource="false" includeConfigurePhase="false" type="InstallableUnit">
+			      <unit id="an.iu" version="1.0.0.thequalifier"/>
+			      <unit id="an.iu2" version="1.3.74"/>
+			      <repository location="http://location.org/p2"/>
+			    </location>
+			  </locations>
+			</target>
 		'''.toString, content)
 	}
-	
+
 	@Test
 	def void testManyLocationManyIU() {
 		val tp1 = parser.parse('''
@@ -170,48 +173,48 @@ class TestTargetGeneration {
 				an.iu2
 			}
 		''')
-		
-		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder);
+
+		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 		resolvedTargetPlatform.resolve(new MetadataRepositoryManagerStub(new IQueryResultProvider<IInstallableUnit>() {
 			override listIUs(URI location) {
 				var List<IInstallableUnit> ret
 				if ("http://location.org/p2".equals(location.toString)) {
-						ret = newImmutableList(
-							IUStub.createBundle("an.iu", Version.createOSGi(1,0,0)) 
-						)
+					ret = newImmutableList(
+						IUStub.createBundle("an.iu", Version.createOSGi(1, 0, 0))
+					)
 				} else if ("http://location2.org/p2".equals(location.toString)) {
-						ret = newImmutableList(
-							IUStub.createBundle("an.iu2", Version.createOSGi(1,3,74, null))
-						)
+					ret = newImmutableList(
+						IUStub.createBundle("an.iu2", Version.createOSGi(1, 3, 74, null))
+					)
 				} else {
 					ret = emptyList
 				}
 				return ret;
 			}
-			
+
 		}), new NullProgressMonitor());
-		
+
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
 		assertEquals('''
-		<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-		<?pde?>
-		<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-		<target name="TP1" sequenceNumber="1">
-		  <locations>
-		    <location includeMode="slicer" includeAllPlatforms="false" includeSource="false" includeConfigurePhase="false" type="InstallableUnit">
-		      <unit id="an.iu" version="1.0.0"/>
-		      <repository location="http://location.org/p2"/>
-		    </location>
-		    <location includeMode="slicer" includeAllPlatforms="false" includeSource="false" includeConfigurePhase="false" type="InstallableUnit">
-		      <unit id="an.iu2" version="1.3.74"/>
-		      <repository location="http://location2.org/p2"/>
-		    </location>
-		  </locations>
-		</target>
+			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+			<?pde?>
+			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
+			<target name="TP1" sequenceNumber="1">
+			  <locations>
+			    <location includeMode="slicer" includeAllPlatforms="false" includeSource="false" includeConfigurePhase="false" type="InstallableUnit">
+			      <unit id="an.iu" version="1.0.0"/>
+			      <repository location="http://location.org/p2"/>
+			    </location>
+			    <location includeMode="slicer" includeAllPlatforms="false" includeSource="false" includeConfigurePhase="false" type="InstallableUnit">
+			      <unit id="an.iu2" version="1.3.74"/>
+			      <repository location="http://location2.org/p2"/>
+			    </location>
+			  </locations>
+			</target>
 		'''.toString, content)
 	}
-	
+
 	@Test
 	def void testOptionSource() {
 		val tp1 = parser.parse('''
@@ -223,37 +226,37 @@ class TestTargetGeneration {
 				an.iu
 			}
 		''')
-		
-		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder);
+
+		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 		resolvedTargetPlatform.resolve(new MetadataRepositoryManagerStub(new IQueryResultProvider<IInstallableUnit>() {
 			override listIUs(URI location) {
 				if ("http://location.org/p2".equals(location.toString)) {
 					newImmutableList(
-						IUStub.createBundle("an.iu", Version.createOSGi(1,0,0, "thequalifier"))
+						IUStub.createBundle("an.iu", Version.createOSGi(1, 0, 0, "thequalifier"))
 					)
 				} else {
 					return emptyList
 				}
 			}
 		}), new NullProgressMonitor());
-		
+
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
 		assertEquals('''
-		<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-		<?pde?>
-		<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-		<target name="TP1" sequenceNumber="1">
-		  <locations>
-		    <location includeMode="slicer" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-		      <unit id="an.iu" version="1.0.0.thequalifier"/>
-		      <repository location="http://location.org/p2"/>
-		    </location>
-		  </locations>
-		</target>
+			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+			<?pde?>
+			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
+			<target name="TP1" sequenceNumber="1">
+			  <locations>
+			    <location includeMode="slicer" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+			      <unit id="an.iu" version="1.0.0.thequalifier"/>
+			      <repository location="http://location.org/p2"/>
+			    </location>
+			  </locations>
+			</target>
 		'''.toString, content)
 	}
-	
+
 	@Test
 	def void testOptionRequirement() {
 		val tp1 = parser.parse('''
@@ -265,37 +268,37 @@ class TestTargetGeneration {
 				an.iu
 			}
 		''')
-		
-		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder);
+
+		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 		resolvedTargetPlatform.resolve(new MetadataRepositoryManagerStub(new IQueryResultProvider<IInstallableUnit>() {
 			override listIUs(URI location) {
 				if ("http://location.org/p2".equals(location.toString)) {
 					newImmutableList(
-						IUStub.createBundle("an.iu", Version.createOSGi(1,0,0, "thequalifier"))
+						IUStub.createBundle("an.iu", Version.createOSGi(1, 0, 0, "thequalifier"))
 					)
 				} else {
 					return emptyList
 				}
 			}
 		}), new NullProgressMonitor());
-		
+
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
 		assertEquals('''
-		<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-		<?pde?>
-		<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-		<target name="TP1" sequenceNumber="1">
-		  <locations>
-		    <location includeMode="planner" includeAllPlatforms="false" includeSource="false" includeConfigurePhase="false" type="InstallableUnit">
-		      <unit id="an.iu" version="1.0.0.thequalifier"/>
-		      <repository location="http://location.org/p2"/>
-		    </location>
-		  </locations>
-		</target>
+			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+			<?pde?>
+			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
+			<target name="TP1" sequenceNumber="1">
+			  <locations>
+			    <location includeMode="planner" includeAllPlatforms="false" includeSource="false" includeConfigurePhase="false" type="InstallableUnit">
+			      <unit id="an.iu" version="1.0.0.thequalifier"/>
+			      <repository location="http://location.org/p2"/>
+			    </location>
+			  </locations>
+			</target>
 		'''.toString, content)
 	}
-	
+
 	@Test
 	def void testOptionIncludeAllPlatforms() {
 		val tp1 = parser.parse('''
@@ -307,37 +310,37 @@ class TestTargetGeneration {
 				an.iu
 			}
 		''')
-		
-		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder);
+
+		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 		resolvedTargetPlatform.resolve(new MetadataRepositoryManagerStub(new IQueryResultProvider<IInstallableUnit>() {
 			override listIUs(URI location) {
 				if ("http://location.org/p2".equals(location.toString)) {
 					newImmutableList(
-						IUStub.createBundle("an.iu", Version.createOSGi(1,0,0, "thequalifier"))
+						IUStub.createBundle("an.iu", Version.createOSGi(1, 0, 0, "thequalifier"))
 					)
 				} else {
 					return emptyList
 				}
 			}
 		}), new NullProgressMonitor());
-		
+
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
 		assertEquals('''
-		<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-		<?pde?>
-		<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-		<target name="TP1" sequenceNumber="1">
-		  <locations>
-		    <location includeMode="slicer" includeAllPlatforms="true" includeSource="false" includeConfigurePhase="false" type="InstallableUnit">
-		      <unit id="an.iu" version="1.0.0.thequalifier"/>
-		      <repository location="http://location.org/p2"/>
-		    </location>
-		  </locations>
-		</target>
+			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+			<?pde?>
+			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
+			<target name="TP1" sequenceNumber="1">
+			  <locations>
+			    <location includeMode="slicer" includeAllPlatforms="true" includeSource="false" includeConfigurePhase="false" type="InstallableUnit">
+			      <unit id="an.iu" version="1.0.0.thequalifier"/>
+			      <repository location="http://location.org/p2"/>
+			    </location>
+			  </locations>
+			</target>
 		'''.toString, content)
 	}
-	
+
 	@Test
 	def void testOptionConfigurePhase() {
 		val tp1 = parser.parse('''
@@ -349,37 +352,37 @@ class TestTargetGeneration {
 				an.iu
 			}
 		''')
-		
-		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder);
+
+		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 		resolvedTargetPlatform.resolve(new MetadataRepositoryManagerStub(new IQueryResultProvider<IInstallableUnit>() {
 			override listIUs(URI location) {
 				if ("http://location.org/p2".equals(location.toString)) {
 					newImmutableList(
-						IUStub.createBundle("an.iu", Version.createOSGi(1,0,0, "thequalifier"))
+						IUStub.createBundle("an.iu", Version.createOSGi(1, 0, 0, "thequalifier"))
 					)
 				} else {
 					return emptyList
 				}
 			}
 		}), new NullProgressMonitor());
-		
+
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
 		assertEquals('''
-		<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-		<?pde?>
-		<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-		<target name="TP1" sequenceNumber="1">
-		  <locations>
-		    <location includeMode="slicer" includeAllPlatforms="false" includeSource="false" includeConfigurePhase="true" type="InstallableUnit">
-		      <unit id="an.iu" version="1.0.0.thequalifier"/>
-		      <repository location="http://location.org/p2"/>
-		    </location>
-		  </locations>
-		</target>
+			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+			<?pde?>
+			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
+			<target name="TP1" sequenceNumber="1">
+			  <locations>
+			    <location includeMode="slicer" includeAllPlatforms="false" includeSource="false" includeConfigurePhase="true" type="InstallableUnit">
+			      <unit id="an.iu" version="1.0.0.thequalifier"/>
+			      <repository location="http://location.org/p2"/>
+			    </location>
+			  </locations>
+			</target>
 		'''.toString, content)
 	}
-	
+
 	@Test
 	def void testEnvOS() {
 		val tp1 = parser.parse('''
@@ -387,22 +390,22 @@ class TestTargetGeneration {
 			
 			environment Win32
 		''')
-		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder);
-		
+		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
+
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
 		assertEquals('''
-		<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-		<?pde?>
-		<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-		<target name="TP1" sequenceNumber="1">
-		  <environment>
-		    <os>win32</os>
-		  </environment>
-		</target>
+			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+			<?pde?>
+			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
+			<target name="TP1" sequenceNumber="1">
+			  <environment>
+			    <os>win32</os>
+			  </environment>
+			</target>
 		'''.toString, content)
 	}
-	
+
 	@Test
 	def void testEnvOSWin32WSWin32() {
 		val tp1 = parser.parse('''
@@ -410,23 +413,23 @@ class TestTargetGeneration {
 			
 			environment Win32 wiN32
 		''')
-		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder);
-		
+		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
+
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
 		assertEquals('''
-		<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-		<?pde?>
-		<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-		<target name="TP1" sequenceNumber="1">
-		  <environment>
-		    <os>win32</os>
-		    <ws>win32</ws>
-		  </environment>
-		</target>
+			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+			<?pde?>
+			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
+			<target name="TP1" sequenceNumber="1">
+			  <environment>
+			    <os>win32</os>
+			    <ws>win32</ws>
+			  </environment>
+			</target>
 		'''.toString, content)
 	}
-	
+
 	@Test
 	def void testEnvWS() {
 		val tp1 = parser.parse('''
@@ -434,22 +437,22 @@ class TestTargetGeneration {
 			
 			environment cocoa
 		''')
-		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder);
-		
+		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
+
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
 		assertEquals('''
-		<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-		<?pde?>
-		<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-		<target name="TP1" sequenceNumber="1">
-		  <environment>
-		    <ws>cocoa</ws>
-		  </environment>
-		</target>
+			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+			<?pde?>
+			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
+			<target name="TP1" sequenceNumber="1">
+			  <environment>
+			    <ws>cocoa</ws>
+			  </environment>
+			</target>
 		'''.toString, content)
 	}
-	
+
 	@Test
 	def void testEnvArch() {
 		val tp1 = parser.parse('''
@@ -457,22 +460,22 @@ class TestTargetGeneration {
 			
 			environment x86_64
 		''')
-		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder);
-		
+		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
+
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
 		assertEquals('''
-		<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-		<?pde?>
-		<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-		<target name="TP1" sequenceNumber="1">
-		  <environment>
-		    <arch>x86_64</arch>
-		  </environment>
-		</target>
+			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+			<?pde?>
+			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
+			<target name="TP1" sequenceNumber="1">
+			  <environment>
+			    <arch>x86_64</arch>
+			  </environment>
+			</target>
 		'''.toString, content)
 	}
-	
+
 	@Test
 	def void testEnvLocale() {
 		val tp1 = parser.parse('''
@@ -480,22 +483,22 @@ class TestTargetGeneration {
 			
 			environment fr_fr
 		''')
-		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder);
-		
+		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
+
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
 		assertEquals('''
-		<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-		<?pde?>
-		<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-		<target name="TP1" sequenceNumber="1">
-		  <environment>
-		    <nl>fr_FR</nl>
-		  </environment>
-		</target>
+			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+			<?pde?>
+			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
+			<target name="TP1" sequenceNumber="1">
+			  <environment>
+			    <nl>fr_FR</nl>
+			  </environment>
+			</target>
 		'''.toString, content)
 	}
-	
+
 	@Test
 	def void testEnvEE() {
 		val tp1 = parser.parse('''
@@ -503,20 +506,20 @@ class TestTargetGeneration {
 			
 			environment JavaSE-1.7
 		''')
-		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder);
-		
+		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
+
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
 		assertEquals('''
-		<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-		<?pde?>
-		<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-		<target name="TP1" sequenceNumber="1">
-		  <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
-		</target>
+			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+			<?pde?>
+			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
+			<target name="TP1" sequenceNumber="1">
+			  <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+			</target>
 		'''.toString, content)
 	}
-	
+
 	@Test
 	def void testEnv1() {
 		val tp1 = parser.parse('''
@@ -524,26 +527,26 @@ class TestTargetGeneration {
 			
 			environment JavaSE-1.7 win32 cocoa x86 en_us
 		''')
-		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder);
-		
+		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
+
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
 		assertEquals('''
-		<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-		<?pde?>
-		<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-		<target name="TP1" sequenceNumber="1">
-		  <environment>
-		    <os>win32</os>
-		    <ws>cocoa</ws>
-		    <arch>x86</arch>
-		    <nl>en_US</nl>
-		  </environment>
-		  <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
-		</target>
+			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+			<?pde?>
+			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
+			<target name="TP1" sequenceNumber="1">
+			  <environment>
+			    <os>win32</os>
+			    <ws>cocoa</ws>
+			    <arch>x86</arch>
+			    <nl>en_US</nl>
+			  </environment>
+			  <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+			</target>
 		'''.toString, content)
 	}
-	
+
 	@Test
 	def void testEnv2() {
 		val tp1 = parser.parse('''
@@ -551,20 +554,122 @@ class TestTargetGeneration {
 			
 			environment win32 linux
 		''')
-		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder);
-		
+		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
+
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
 		assertEquals('''
-		<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-		<?pde?>
-		<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-		<target name="TP1" sequenceNumber="1">
-		  <environment>
-		    <os>linux</os>
-		    <ws>win32</ws>
-		  </environment>
-		</target>
+			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+			<?pde?>
+			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
+			<target name="TP1" sequenceNumber="1">
+			  <environment>
+			    <os>linux</os>
+			    <ws>win32</ws>
+			  </environment>
+			</target>
+		'''.toString, content)
+	}
+
+	@Test
+	def void testMavenLocationWithoutFeature() {
+		val tp1 = parser.parse('''
+			target "TP1"
+			
+			maven MavenDependencies scope=compile dependencyDepth=infinite missingManifest=generate includeSources {
+				dependency {
+					groupId="org.mockito"
+					artifactId="mockito-core"
+					version="3.12.4"
+					type="jar"
+				}
+			}
+		''')
+		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
+		resolvedTargetPlatform.resolve(new MetadataRepositoryManagerStub(new IQueryResultProvider<IInstallableUnit>() {
+			override listIUs(URI location) {
+			}
+		}), new NullProgressMonitor());
+
+		val gen = new TargetDefinitionGenerator();
+		val content = gen.generate(resolvedTargetPlatform, 1);
+		assertEquals('''
+			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+			<?pde?>
+			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
+			<target name="TP1" sequenceNumber="1">
+			  <locations>
+			    <location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven" label="MavenDependencies">
+			    <dependencies>
+			    	<dependency>
+			    		<groupId>org.mockito</groupId>
+			    		<artifactId>mockito-core</artifactId>
+			    		<version>3.12.4</version>
+			    		<type>jar</type>
+			    	</dependency>
+			    </dependencies>
+			    </location>
+			  </locations>
+			</target>
+		'''.toString, content)
+	}
+
+	@Test
+	def void testMavenLocationWithFeature() {
+		val tp1 = parser.parse('''
+			target "TP1"
+			
+			maven MavenDependencies scope=compile,test dependencyDepth=infinite missingManifest=generate includeSources {
+				feature {
+					id="my.feature.com"
+					name="My little feature"
+					version="1.0.0.qualifier"
+				}
+				dependency {
+					groupId="org.mockito"
+					artifactId="mockito-core"
+					version="3.12.4"
+					type="jar"
+				}
+			}
+		''')
+		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
+		resolvedTargetPlatform.resolve(new MetadataRepositoryManagerStub(new IQueryResultProvider<IInstallableUnit>() {
+			override listIUs(URI location) {
+			}
+		}), new NullProgressMonitor());
+
+		val gen = new TargetDefinitionGenerator();
+		val content = gen.generate(resolvedTargetPlatform, 1);
+		assertEquals('''
+			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+			<?pde?>
+			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
+			<target name="TP1" sequenceNumber="1">
+			  <locations>
+			    <location includeDependencyDepth="infinite" includeDependencyScopes="compile,test" includeSource="true" missingManifest="generate" type="Maven" label="MavenDependencies">
+			    <feature id="my.feature.com" label="My little feature" provider-name="" version="1.0.0.qualifier">
+			    	<description url="http://www.example.com/description">
+			    		[Enter Feature Description here.]
+			    	</description>
+			    	<copyright url="http://www.example.com/copyright">
+			    		[Enter Copyright Description here.]
+			    	</copyright>
+			    	<license url="http://www.example.com/license">
+			    		[Enter License Description here.]
+			    	</license>
+			    </feature>
+			    <dependencies>
+			    	<dependency>
+			    		<groupId>org.mockito</groupId>
+			    		<artifactId>mockito-core</artifactId>
+			    		<version>3.12.4</version>
+			    		<type>jar</type>
+			    	</dependency>
+			    </dependencies>
+			    </location>
+			  </locations>
+			</target>
 		'''.toString, content)
 	}
 }

--- a/org.eclipse.cbi.targetplatform/src/main/java/org/eclipse/cbi/targetplatform/pde/Converter.java
+++ b/org.eclipse.cbi.targetplatform/src/main/java/org/eclipse/cbi/targetplatform/pde/Converter.java
@@ -27,6 +27,7 @@ import org.eclipse.cbi.targetplatform.model.TargetPlatform;
 import org.eclipse.cbi.targetplatform.model.TargetPlatformPackage;
 import org.eclipse.cbi.targetplatform.resolved.ResolvedTargetPlatform;
 import org.eclipse.cbi.targetplatform.util.LocationIndexBuilder;
+import org.eclipse.cbi.targetplatform.util.MavenLocationIndexBuilder;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -63,6 +64,9 @@ public class Converter {
 	
 	@Inject
 	private LocationIndexBuilder indexBuilder;
+	
+	@Inject
+	private MavenLocationIndexBuilder mavenIndexBuilder;
 	
 	@Inject
 	private IProvisioningAgent agent;
@@ -132,7 +136,7 @@ public class Converter {
 		
 		try {
 			IMetadataRepositoryManager repositoryManager = (IMetadataRepositoryManager) agent.getService(IMetadataRepositoryManager.SERVICE_NAME);
-			ResolvedTargetPlatform resolvedTargetPlatform = ResolvedTargetPlatform.create(targetPlatform, indexBuilder);
+			ResolvedTargetPlatform resolvedTargetPlatform = ResolvedTargetPlatform.create(targetPlatform, indexBuilder, mavenIndexBuilder);
 			subMonitor.worked(5);
 			
 			if (subMonitor.isCanceled()) {

--- a/org.eclipse.cbi.targetplatform/src/main/java/org/eclipse/cbi/targetplatform/resolved/ResolvedTargetPlatform.java
+++ b/org.eclipse.cbi.targetplatform/src/main/java/org/eclipse/cbi/targetplatform/resolved/ResolvedTargetPlatform.java
@@ -26,6 +26,7 @@ import org.eclipse.cbi.targetplatform.model.Location;
 import org.eclipse.cbi.targetplatform.model.Option;
 import org.eclipse.cbi.targetplatform.model.TargetPlatform;
 import org.eclipse.cbi.targetplatform.util.LocationIndexBuilder;
+import org.eclipse.cbi.targetplatform.util.MavenLocationIndexBuilder;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.SubMonitor;
@@ -114,7 +115,7 @@ public class ResolvedTargetPlatform {
 		return ret;
 	}
 	
-	public static ResolvedTargetPlatform create(TargetPlatform targetPlatform, LocationIndexBuilder indexBuilder) throws URISyntaxException {
+	public static ResolvedTargetPlatform create(TargetPlatform targetPlatform, LocationIndexBuilder indexBuilder, MavenLocationIndexBuilder mavenIndexBuilder) throws URISyntaxException {
 		Preconditions.checkArgument(targetPlatform != null);
 		LinkedList<ResolvedLocation> locations = Lists.newLinkedList();
 		
@@ -125,11 +126,10 @@ public class ResolvedTargetPlatform {
 			locations.addFirst(resolvedLocation);
 		}
 		
-		List<ResolvedMavenLocation> mavenLocations = targetPlatform.getMavenLocations().stream() //
+		List<ResolvedMavenLocation> mavenLocations = mavenIndexBuilder.getLocationIndex(targetPlatform).values().stream() // 
 				.map(ResolvedMavenLocation::new)
 				.collect(Collectors.toList());
-		
-		
+				
 		final EnumSet<Option> options = getOptionSet(targetPlatform.getOptions());
 		return new ResolvedTargetPlatform(targetPlatform.getName(), locations, mavenLocations, options, Environment.create(targetPlatform));
 	}

--- a/org.eclipse.cbi.targetplatform/src/main/java/org/eclipse/cbi/targetplatform/util/AbstractLocationIndexBuilder.xtend
+++ b/org.eclipse.cbi.targetplatform/src/main/java/org/eclipse/cbi/targetplatform/util/AbstractLocationIndexBuilder.xtend
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2012-2020 Obeo and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Mikael Barbero (Obeo) - initial API and implementation
+ */
+package org.eclipse.cbi.targetplatform.util
+
+import com.google.common.collect.LinkedListMultimap
+import com.google.common.collect.ListMultimap
+import com.google.common.collect.Multimaps
+import com.google.inject.Inject
+import java.util.LinkedList
+import java.util.List
+import java.util.Set
+import org.eclipse.cbi.targetplatform.model.IncludeDeclaration
+import org.eclipse.cbi.targetplatform.model.TargetPlatform
+import org.eclipse.emf.ecore.resource.Resource
+import org.eclipse.xtext.EcoreUtil2
+import org.eclipse.xtext.scoping.impl.ImportUriResolver
+
+abstract class AbstractLocationIndexBuilder<TYPE> {
+	
+	@Inject
+	ImportUriResolver resolver;
+	
+	def ListMultimap<String, TYPE> getLocationIndex(TargetPlatform targetPlatform) {
+		val locationList = getLocations(
+			newLinkedHashSet(targetPlatform), 
+			newLinkedList(targetPlatform)
+		)
+		return LinkedListMultimap.create(Multimaps.index(locationList, [mappingKey]))
+	}
+	
+	protected abstract def String getMappingKey(TYPE location); 
+	protected abstract def boolean isValidLocation(Object location); 
+	
+	private def List<TYPE> getLocations(Set<TargetPlatform> visited, List<TargetPlatform> toBeVisited) {
+		val List<TYPE> locations = newArrayList()
+		
+		toBeVisited.forEach[
+			val includes = newLinkedList
+			it.contents.reverseView.forEach[content|
+				if (content.isValidLocation) {
+					if (!includes.empty) {
+						locations.addAll(getLocationFromVisitedIncludes(it, includes, visited))
+						includes.clear
+					}
+					locations.add(content as TYPE)
+				} else if (content instanceof IncludeDeclaration) {
+					includes.add(content)
+				}
+			]
+			
+			if (!includes.empty) {
+				locations.addAll(getLocationFromVisitedIncludes(it, includes, visited))
+				includes.clear
+			}
+		]
+		return locations
+	}
+	
+	private def getLocationFromVisitedIncludes(TargetPlatform parent, List<IncludeDeclaration> includes, Set<TargetPlatform> visited) {
+		val importedLocation = includes
+			.map[getImportedTargetPlatform(parent.eResource, it)]
+			.filterNull
+			.filter[!visited.contains(it)].toList
+		
+		visited.addAll(importedLocation)
+		
+		return getLocations(visited, importedLocation)
+	}
+
+	/**
+	 * Returns all imported target platforms in a BSF fashion. The returned collection has 
+	 * an iteration order reflecting the import overriding: the last import override precedent ones
+	 * and the deepest import is of least importance. E.g.
+	 * A includes B, C and D
+	 * B includes E, F and G
+	 * C includes H, I and J
+	 * D includes K, L and M
+	 * 
+	 * The returned collection for A is : D, C, B, M, L, K, J, I, H, G, F, E 
+	 */
+	def getImportedTargetPlatforms(TargetPlatform targetPlatform) {
+		val visited = newLinkedHashSet();
+		val queue = newLinkedList();
+		val includeRet = newLinkedList();
+		queue.addLast(targetPlatform)
+		visited.add(targetPlatform)
+		while(!queue.empty) {
+			val tr = newLinkedList();
+			val t = queue.removeLast
+			for(unvisited : t.includes.map[getImportedTargetPlatform(t.eResource, it)].filterNull) {
+				if (!visited.contains(unvisited)) {
+					visited.add(unvisited)
+					queue.addLast(unvisited)
+					tr.addFirst(unvisited)
+				}
+			}
+			includeRet.addAll(tr)
+		}
+		return includeRet
+	}
+
+	def checkIncludeCycle(TargetPlatform targetPlatform) {
+		val acc = newLinkedHashSet();
+		val s = newLinkedList();
+		return 
+			if (checkIncludeCycle(targetPlatform, acc, s)) {
+				s.reverse
+			} else {
+				newImmutableList()
+			}
+	}
+	
+	private def boolean checkIncludeCycle(TargetPlatform targetPlatform, Set<TargetPlatform> visited, LinkedList<TargetPlatform> s) {
+		s.addFirst(targetPlatform)
+		val context = targetPlatform.eResource
+		val includedTPs = targetPlatform.includes.map[getImportedTargetPlatform(context, it)].filterNull.toSet
+		for(includedTP : includedTPs) {
+			if (s.contains(includedTP)) {
+				s.addFirst(includedTP)
+				return true
+			}
+			
+			visited.add(includedTP)
+			
+			if (checkIncludeCycle(includedTP, visited, s)) {
+				return true;
+			}
+		}
+		
+		s.removeFirst
+		return false
+	}
+
+	def TargetPlatform getImportedTargetPlatform(Resource context, IncludeDeclaration include) {
+		var TargetPlatform ret = null;
+		val resource = EcoreUtil2.getResource(context, resolver.resolve(include));
+		var root = resource?.getContents()?.head;
+		if (root instanceof TargetPlatform) {
+			ret = root;
+		}
+		return ret;
+	}
+}

--- a/org.eclipse.cbi.targetplatform/src/main/java/org/eclipse/cbi/targetplatform/util/LocationIndexBuilder.xtend
+++ b/org.eclipse.cbi.targetplatform/src/main/java/org/eclipse/cbi/targetplatform/util/LocationIndexBuilder.xtend
@@ -13,34 +13,18 @@
  */
 package org.eclipse.cbi.targetplatform.util
 
-import com.google.common.collect.LinkedListMultimap
-import com.google.common.collect.ListMultimap
-import com.google.common.collect.Multimaps
-import com.google.inject.Inject
-import java.util.LinkedList
-import java.util.List
-import java.util.Set
-import org.eclipse.cbi.targetplatform.model.IncludeDeclaration
 import org.eclipse.cbi.targetplatform.model.Location
-import org.eclipse.cbi.targetplatform.model.TargetPlatform
 import org.eclipse.emf.common.util.URI
-import org.eclipse.emf.ecore.resource.Resource
-import org.eclipse.xtext.EcoreUtil2
-import org.eclipse.xtext.scoping.impl.ImportUriResolver
 
-class LocationIndexBuilder {
-	
-	@Inject
-	ImportUriResolver resolver;
-	
-	def ListMultimap<String, Location> getLocationIndex(TargetPlatform targetPlatform) {
-		val locationList = getLocations(
-			newLinkedHashSet(targetPlatform), 
-			newLinkedList(targetPlatform)
-		)
-		return LinkedListMultimap.create(Multimaps.index(locationList, [uri.normalizeURI]))
+class LocationIndexBuilder extends AbstractLocationIndexBuilder<Location> {
+	override protected getMappingKey(Location location) {
+		return location.uri.normalizeURI
 	}
-
+	
+	override protected isValidLocation(Object location) {
+		return location instanceof Location
+	}
+	
 	private static def String normalizeURI(String uri) {
 		if (uri === null) {
 			return null
@@ -50,115 +34,5 @@ class LocationIndexBuilder {
 			return uriValue.trimSegments(1).toString
 		}
 		return uri
-	}
-
-	private def List<Location> getLocations(Set<TargetPlatform> visited, List<TargetPlatform> toBeVisited) {
-		val locations = newArrayList()
-		
-		toBeVisited.forEach[
-			val includes = newLinkedList
-			it.contents.reverseView.forEach[content|
-				if (content instanceof Location) {
-					if (!includes.empty) {
-						locations.addAll(getLocationFromVisitedIncludes(it, includes, visited))
-						includes.clear
-					}
-					locations.add(content)
-				} else if (content instanceof IncludeDeclaration) {
-					includes.add(content)
-				}
-			]
-			
-			if (!includes.empty) {
-				locations.addAll(getLocationFromVisitedIncludes(it, includes, visited))
-				includes.clear
-			}
-		]
-		return locations
-	}
-	
-	private def getLocationFromVisitedIncludes(TargetPlatform parent, List<IncludeDeclaration> includes, Set<TargetPlatform> visited) {
-		val importedLocation = includes
-			.map[getImportedTargetPlatform(parent.eResource, it)]
-			.filterNull
-			.filter[!visited.contains(it)].toList
-		
-		visited.addAll(importedLocation)
-		
-		return getLocations(visited, importedLocation)
-	}
-
-	/**
-	 * Returns all imported target platforms in a BSF fashion. The returned collection has 
-	 * an iteration order reflecting the import overriding: the last import override precedent ones
-	 * and the deepest import is of least importance. E.g.
-	 * A includes B, C and D
-	 * B includes E, F and G
-	 * C includes H, I and J
-	 * D includes K, L and M
-	 * 
-	 * The returned collection for A is : D, C, B, M, L, K, J, I, H, G, F, E 
-	 */
-	def getImportedTargetPlatforms(TargetPlatform targetPlatform) {
-		val visited = newLinkedHashSet();
-		val queue = newLinkedList();
-		val includeRet = newLinkedList();
-		queue.addLast(targetPlatform)
-		visited.add(targetPlatform)
-		while(!queue.empty) {
-			val tr = newLinkedList();
-			val t = queue.removeLast
-			for(unvisited : t.includes.map[getImportedTargetPlatform(t.eResource, it)].filterNull) {
-				if (!visited.contains(unvisited)) {
-					visited.add(unvisited)
-					queue.addLast(unvisited)
-					tr.addFirst(unvisited)
-				}
-			}
-			includeRet.addAll(tr)
-		}
-		return includeRet
-	}
-
-	def checkIncludeCycle(TargetPlatform targetPlatform) {
-		val acc = newLinkedHashSet();
-		val s = newLinkedList();
-		return 
-			if (checkIncludeCycle(targetPlatform, acc, s)) {
-				s.reverse
-			} else {
-				newImmutableList()
-			}
-	}
-	
-	private def boolean checkIncludeCycle(TargetPlatform targetPlatform, Set<TargetPlatform> visited, LinkedList<TargetPlatform> s) {
-		s.addFirst(targetPlatform)
-		val context = targetPlatform.eResource
-		val includedTPs = targetPlatform.includes.map[getImportedTargetPlatform(context, it)].filterNull.toSet
-		for(includedTP : includedTPs) {
-			if (s.contains(includedTP)) {
-				s.addFirst(includedTP)
-				return true
-			}
-			
-			visited.add(includedTP)
-			
-			if (checkIncludeCycle(includedTP, visited, s)) {
-				return true;
-			}
-		}
-		
-		s.removeFirst
-		return false
-	}
-
-	def TargetPlatform getImportedTargetPlatform(Resource context, IncludeDeclaration include) {
-		var TargetPlatform ret = null;
-		val resource = EcoreUtil2.getResource(context, resolver.resolve(include));
-		var root = resource?.getContents()?.head;
-		if (root instanceof TargetPlatform) {
-			ret = root;
-		}
-		return ret;
 	}
 }

--- a/org.eclipse.cbi.targetplatform/src/main/java/org/eclipse/cbi/targetplatform/util/MavenLocationIndexBuilder.xtend
+++ b/org.eclipse.cbi.targetplatform/src/main/java/org/eclipse/cbi/targetplatform/util/MavenLocationIndexBuilder.xtend
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2012-2020 Obeo and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Mikael Barbero (Obeo) - initial API and implementation
+ */
+package org.eclipse.cbi.targetplatform.util
+
+import org.eclipse.cbi.targetplatform.model.MavenLocation
+
+class MavenLocationIndexBuilder extends AbstractLocationIndexBuilder<MavenLocation> {
+	override protected getMappingKey(MavenLocation location) {
+		return location.label.toLowerCase
+	}
+	
+	override protected isValidLocation(Object location) {
+		location instanceof MavenLocation
+	}
+	
+}


### PR DESCRIPTION
I reworked the part which creates the resolved maven locations, reusing the code from the location index builder.

Also removed the test scope from the templates, because tycho seems to have some problems with it.

Signed-off-by: Hannes Niederhausen <hniederhausen@itemis.de>