### PR TITLE
Fix whitespace and remove useless feature metadata in maven targets

### DIFF
--- a/org.eclipse.cbi.targetplatform.tests/src/main/java/org/eclipse/cbi/targetplatform/tests/TestTargetGeneration.xtend
+++ b/org.eclipse.cbi.targetplatform.tests/src/main/java/org/eclipse/cbi/targetplatform/tests/TestTargetGeneration.xtend
@@ -1,13 +1,13 @@
 /**
  * Copyright (c) 2012-2014 Obeo and others.
- * 
+ *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     Mikael Barbero (Obeo) - initial API and implementation
  */
@@ -65,7 +65,7 @@ class TestTargetGeneration {
 
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
-		assertEquals('''
+		assertTarget('''
 			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 			<?pde?>
 			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
@@ -74,11 +74,16 @@ class TestTargetGeneration {
 		'''.toString, content)
 	}
 
+	def static assertTarget(String expectedContent, String actualContent) {
+		assertEquals(expectedContent, actualContent)
+		assertFalse(actualContent.contains('\t'))
+	}
+
 	@Test
 	def void testSingleLocationSingleIU() {
 		val tp1 = parser.parse('''
 			target "TP1"
-			
+
 			location "http://location.org/p2" {
 				an.iu
 			}
@@ -99,7 +104,7 @@ class TestTargetGeneration {
 
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
-		assertEquals('''
+		assertTarget('''
 			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 			<?pde?>
 			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
@@ -118,7 +123,7 @@ class TestTargetGeneration {
 	def void testSingleLocationManyIU() {
 		val tp1 = parser.parse('''
 			target "TP1"
-			
+
 			location "http://location.org/p2" {
 				an.iu
 				an.iu2;version=[1.2.0,2.0.0)
@@ -144,7 +149,7 @@ class TestTargetGeneration {
 
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
-		assertEquals('''
+		assertTarget('''
 			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 			<?pde?>
 			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
@@ -164,11 +169,11 @@ class TestTargetGeneration {
 	def void testManyLocationManyIU() {
 		val tp1 = parser.parse('''
 			target "TP1"
-			
+
 			location "http://location.org/p2" {
 				an.iu
 			}
-			
+
 			location "http://location2.org/p2" {
 				an.iu2
 			}
@@ -196,7 +201,7 @@ class TestTargetGeneration {
 
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
-		assertEquals('''
+		assertTarget('''
 			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 			<?pde?>
 			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
@@ -219,9 +224,9 @@ class TestTargetGeneration {
 	def void testOptionSource() {
 		val tp1 = parser.parse('''
 			target "TP1"
-			
+
 			with source
-			
+
 			location "http://location.org/p2" {
 				an.iu
 			}
@@ -242,7 +247,7 @@ class TestTargetGeneration {
 
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
-		assertEquals('''
+		assertTarget('''
 			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 			<?pde?>
 			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
@@ -261,9 +266,9 @@ class TestTargetGeneration {
 	def void testOptionRequirement() {
 		val tp1 = parser.parse('''
 			target "TP1"
-			
+
 			with requirements
-			
+
 			location "http://location.org/p2" {
 				an.iu
 			}
@@ -284,7 +289,7 @@ class TestTargetGeneration {
 
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
-		assertEquals('''
+		assertTarget('''
 			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 			<?pde?>
 			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
@@ -303,9 +308,9 @@ class TestTargetGeneration {
 	def void testOptionIncludeAllPlatforms() {
 		val tp1 = parser.parse('''
 			target "TP1"
-			
+
 			with allEnvironments
-			
+
 			location "http://location.org/p2" {
 				an.iu
 			}
@@ -326,7 +331,7 @@ class TestTargetGeneration {
 
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
-		assertEquals('''
+		assertTarget('''
 			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 			<?pde?>
 			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
@@ -345,9 +350,9 @@ class TestTargetGeneration {
 	def void testOptionConfigurePhase() {
 		val tp1 = parser.parse('''
 			target "TP1"
-			
+
 			with configurePhase
-			
+
 			location "http://location.org/p2" {
 				an.iu
 			}
@@ -368,7 +373,7 @@ class TestTargetGeneration {
 
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
-		assertEquals('''
+		assertTarget('''
 			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 			<?pde?>
 			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
@@ -387,14 +392,14 @@ class TestTargetGeneration {
 	def void testEnvOS() {
 		val tp1 = parser.parse('''
 			target "TP1"
-			
+
 			environment Win32
 		''')
 		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
-		assertEquals('''
+		assertTarget('''
 			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 			<?pde?>
 			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
@@ -410,14 +415,14 @@ class TestTargetGeneration {
 	def void testEnvOSWin32WSWin32() {
 		val tp1 = parser.parse('''
 			target "TP1"
-			
+
 			environment Win32 wiN32
 		''')
 		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
-		assertEquals('''
+		assertTarget('''
 			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 			<?pde?>
 			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
@@ -434,14 +439,14 @@ class TestTargetGeneration {
 	def void testEnvWS() {
 		val tp1 = parser.parse('''
 			target "TP1"
-			
+
 			environment cocoa
 		''')
 		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
-		assertEquals('''
+		assertTarget('''
 			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 			<?pde?>
 			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
@@ -457,14 +462,14 @@ class TestTargetGeneration {
 	def void testEnvArch() {
 		val tp1 = parser.parse('''
 			target "TP1"
-			
+
 			environment x86_64
 		''')
 		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
-		assertEquals('''
+		assertTarget('''
 			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 			<?pde?>
 			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
@@ -480,14 +485,14 @@ class TestTargetGeneration {
 	def void testEnvLocale() {
 		val tp1 = parser.parse('''
 			target "TP1"
-			
+
 			environment fr_fr
 		''')
 		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
-		assertEquals('''
+		assertTarget('''
 			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 			<?pde?>
 			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
@@ -503,14 +508,14 @@ class TestTargetGeneration {
 	def void testEnvEE() {
 		val tp1 = parser.parse('''
 			target "TP1"
-			
+
 			environment JavaSE-1.7
 		''')
 		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
-		assertEquals('''
+		assertTarget('''
 			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 			<?pde?>
 			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
@@ -524,14 +529,14 @@ class TestTargetGeneration {
 	def void testEnv1() {
 		val tp1 = parser.parse('''
 			target "TP1"
-			
+
 			environment JavaSE-1.7 win32 cocoa x86 en_us
 		''')
 		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
-		assertEquals('''
+		assertTarget('''
 			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 			<?pde?>
 			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
@@ -551,14 +556,14 @@ class TestTargetGeneration {
 	def void testEnv2() {
 		val tp1 = parser.parse('''
 			target "TP1"
-			
+
 			environment win32 linux
 		''')
 		val resolvedTargetPlatform = ResolvedTargetPlatform.create(tp1, indexBuilder, mavenIndexBuilder);
 
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
-		assertEquals('''
+		assertTarget('''
 			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 			<?pde?>
 			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
@@ -575,7 +580,7 @@ class TestTargetGeneration {
 	def void testMavenLocationWithoutFeature() {
 		val tp1 = parser.parse('''
 			target "TP1"
-			
+
 			maven MavenDependencies scope=compile dependencyDepth=infinite missingManifest=generate includeSources {
 				dependency {
 					groupId="org.mockito"
@@ -593,21 +598,21 @@ class TestTargetGeneration {
 
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
-		assertEquals('''
+		assertTarget('''
 			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 			<?pde?>
 			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
 			<target name="TP1" sequenceNumber="1">
 			  <locations>
 			    <location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven" label="MavenDependencies">
-			    <dependencies>
-			    	<dependency>
-			    		<groupId>org.mockito</groupId>
-			    		<artifactId>mockito-core</artifactId>
-			    		<version>3.12.4</version>
-			    		<type>jar</type>
-			    	</dependency>
-			    </dependencies>
+			      <dependencies>
+			        <dependency>
+			          <groupId>org.mockito</groupId>
+			          <artifactId>mockito-core</artifactId>
+			          <version>3.12.4</version>
+			          <type>jar</type>
+			        </dependency>
+			      </dependencies>
 			    </location>
 			  </locations>
 			</target>
@@ -618,7 +623,7 @@ class TestTargetGeneration {
 	def void testMavenLocationWithFeature() {
 		val tp1 = parser.parse('''
 			target "TP1"
-			
+
 			maven MavenDependencies scope=compile,test dependencyDepth=infinite missingManifest=generate includeSources {
 				feature {
 					id="my.feature.com"
@@ -641,32 +646,23 @@ class TestTargetGeneration {
 
 		val gen = new TargetDefinitionGenerator();
 		val content = gen.generate(resolvedTargetPlatform, 1);
-		assertEquals('''
+		assertTarget('''
 			<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 			<?pde?>
 			<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
 			<target name="TP1" sequenceNumber="1">
 			  <locations>
 			    <location includeDependencyDepth="infinite" includeDependencyScopes="compile,test" includeSource="true" missingManifest="generate" type="Maven" label="MavenDependencies">
-			    <feature id="my.feature.com" label="My little feature" provider-name="" version="1.0.0.qualifier">
-			    	<description url="http://www.example.com/description">
-			    		[Enter Feature Description here.]
-			    	</description>
-			    	<copyright url="http://www.example.com/copyright">
-			    		[Enter Copyright Description here.]
-			    	</copyright>
-			    	<license url="http://www.example.com/license">
-			    		[Enter License Description here.]
-			    	</license>
-			    </feature>
-			    <dependencies>
-			    	<dependency>
-			    		<groupId>org.mockito</groupId>
-			    		<artifactId>mockito-core</artifactId>
-			    		<version>3.12.4</version>
-			    		<type>jar</type>
-			    	</dependency>
-			    </dependencies>
+			      <feature id="my.feature.com" label="My little feature" provider-name="" version="1.0.0.qualifier">
+			      </feature>
+			      <dependencies>
+			        <dependency>
+			          <groupId>org.mockito</groupId>
+			          <artifactId>mockito-core</artifactId>
+			          <version>3.12.4</version>
+			          <type>jar</type>
+			        </dependency>
+			      </dependencies>
 			    </location>
 			  </locations>
 			</target>

--- a/org.eclipse.cbi.targetplatform/src/main/java/org/eclipse/cbi/targetplatform/pde/TargetDefinitionGenerator.xtend
+++ b/org.eclipse.cbi.targetplatform/src/main/java/org/eclipse/cbi/targetplatform/pde/TargetDefinitionGenerator.xtend
@@ -22,8 +22,8 @@ import org.eclipse.cbi.targetplatform.resolved.ResolvedTargetPlatform
 import static com.google.common.base.Preconditions.*
 
 class TargetDefinitionGenerator {
-	
-	
+
+
 	def String generate(ResolvedTargetPlatform targetPlatform, int sequenceNumber) {
 		checkNotNull(targetPlatform)
 		val numLocations = targetPlatform.locations.size+targetPlatform.mavenLocations.size
@@ -42,10 +42,10 @@ class TargetDefinitionGenerator {
 		    «ENDFOR»
 		  </locations>
 		  «ENDIF»
-		  «IF (targetPlatform.environment !== null && 
-			  	(!targetPlatform.environment.os.nullOrEmpty || 
-			  	 !targetPlatform.environment.ws.nullOrEmpty || 
-			  	 !targetPlatform.environment.arch.nullOrEmpty || 
+		  «IF (targetPlatform.environment !== null &&
+			  	(!targetPlatform.environment.os.nullOrEmpty ||
+			  	 !targetPlatform.environment.ws.nullOrEmpty ||
+			  	 !targetPlatform.environment.arch.nullOrEmpty ||
 			  	 !targetPlatform.environment.nl.nullOrEmpty)
 		  )»
 		  <environment>
@@ -69,61 +69,52 @@ class TargetDefinitionGenerator {
 		</target>
 		'''
 	}
-	
+
 	def generateMavenLocation(ResolvedTargetPlatform platform, ResolvedMavenLocation mavenLocation) {
-		
+
 		val scopeValue = mavenLocation.scope
 		val inclSource = mavenLocation.includeSources
 		val missingManifest = mavenLocation.missingManifest
 		val depDepth = mavenLocation.dependencyDepth
 		val label = mavenLocation.label
 		val genFeature = mavenLocation.generatedFeature
-		
+
 		'''
 		<location includeDependencyDepth="«depDepth»" includeDependencyScopes="«scopeValue»" includeSource="«inclSource»" missingManifest="«missingManifest»" type="Maven" label="«label»">
-		«IF genFeature!==null»
-		<feature id="«genFeature.id»" label="«genFeature.name»" provider-name="«genFeature.vendor»" version="«genFeature.version»">
-			<description url="http://www.example.com/description">
-				[Enter Feature Description here.]
-			</description>
-			<copyright url="http://www.example.com/copyright">
-				[Enter Copyright Description here.]
-			</copyright>
-			<license url="http://www.example.com/license">
-				[Enter License Description here.]
-			</license>
-			«FOR iu:genFeature.additionalBundles»
-			<plugin download-size="0" id="«iu.ID»" install-size="0" unpack="false" version="0.0.0"/>
-			«ENDFOR»
-		</feature>
-		«ENDIF»
-		<dependencies>
-			«FOR dep:mavenLocation.mavenDependencies»
-			<dependency>
-				<groupId>«dep.groupId»</groupId>
-				<artifactId>«dep.artifactId»</artifactId>
-				<version>«dep.version»</version>
-				«IF dep.hasClassifier»
-				<classifier>«dep.classifier»</classifier>
-				«ENDIF»
-				<type>«dep.type»</type>
-			</dependency>
-			«ENDFOR»
-		</dependencies>
-		«IF mavenLocation.hasAdditionalRepositories»
-		<repositories>
-			«FOR repEntry : mavenLocation.repositoryMap.entrySet»
-			<repository>
-				<id>«repEntry.key»</id>
-				<url>«repEntry.value»</url>
-			</repository>
-			«ENDFOR»
-		</repositories>
-		«ENDIF»
+		  «IF genFeature!==null»
+		  <feature id="«genFeature.id»" label="«genFeature.name»" provider-name="«genFeature.vendor»" version="«genFeature.version»">
+		    «FOR iu:genFeature.additionalBundles»
+		    <plugin download-size="0" id="«iu.ID»" install-size="0" unpack="false" version="0.0.0"/>
+		    «ENDFOR»
+		  </feature>
+		  «ENDIF»
+		  <dependencies>
+		    «FOR dep:mavenLocation.mavenDependencies»
+		    <dependency>
+		      <groupId>«dep.groupId»</groupId>
+		      <artifactId>«dep.artifactId»</artifactId>
+		      <version>«dep.version»</version>
+		      «IF dep.hasClassifier»
+		      <classifier>«dep.classifier»</classifier>
+		      «ENDIF»
+		      <type>«dep.type»</type>
+		    </dependency>
+		    «ENDFOR»
+		  </dependencies>
+		  «IF mavenLocation.hasAdditionalRepositories»
+		  <repositories>
+		    «FOR repEntry : mavenLocation.repositoryMap.entrySet»
+		    <repository>
+		      <id>«repEntry.key»</id>
+		      <url>«repEntry.value»</url>
+		    </repository>
+		    «ENDFOR»
+		  </repositories>
+		  «ENDIF»
 		</location>
 		'''
 	}
-	
+
 	private def String generateLocation(ResolvedTargetPlatform targetPlatform, ResolvedLocation location) {
 		val options =
 			if (!targetPlatform.options.empty) {
@@ -131,18 +122,18 @@ class TargetDefinitionGenerator {
 			} else {
 				location.options
 			}
-		
+
 		val includeMode = 'includeMode="' + (if (options.contains(Option.INCLUDE_REQUIRED)) 'planner' else 'slicer') + '"'
 		val includeAllPlatforms = 'includeAllPlatforms="' + options.contains(Option.INCLUDE_ALL_ENVIRONMENTS) + '"'
 		val includeSource = 'includeSource="' + options.contains(Option.INCLUDE_SOURCE) + '"'
 		val includeConfigurePhase = 'includeConfigurePhase="' + options.contains(Option.INCLUDE_CONFIGURE_PHASE) + '"'
-		val locationAttributes = 
-				includeMode + ' ' + includeAllPlatforms +  ' ' + 
-				includeSource + ' ' + includeConfigurePhase 
-		 
-		val repositoryAttributes = 
+		val locationAttributes =
+				includeMode + ' ' + includeAllPlatforms +  ' ' +
+				includeSource + ' ' + includeConfigurePhase
+
+		val repositoryAttributes =
 			'''«IF !location.ID.nullOrEmpty»id="«location.ID»" «ENDIF»location="«location.URI»"'''
-			
+
 		'''
 		<location «locationAttributes» type="InstallableUnit">
 		  «FOR iu : location.resolvedIUs»


### PR DESCRIPTION
All other parts of the generated target use an indentation of 2 spaces. Use the same in the Maven part. Also remove the useless metadata from the generated (optional) feature. There is no need to have those tags, and the generated nonsense data is end-user visible.

Attention reviewers: You may need to enable whitespace display in whatever review tool you use.