### PR TITLE
Avoid unwanted build promotion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -458,7 +458,7 @@
       <activation>
         <property>
           <name>promote</name>
-          <value>!false</value>
+          <value>true</value>
         </property>
       </activation>
       <modules>


### PR DESCRIPTION
Maven profiles using properties with "!someValue" syntax are _active_ when the property is not defined at all. Therefore building on command line with "mvn clean verify" triggers an unwanted promotion.