### PR TITLE
fix workspace setup after Eclipse 2024-03 release

### DIFF
--- a/org.eclipse.cbi.targetplatform.tests/src/main/java/org/eclipse/cbi/targetplatform/tests/stubs/p2/MetadataRepositoryStub.java
+++ b/org.eclipse.cbi.targetplatform.tests/src/main/java/org/eclipse/cbi/targetplatform/tests/stubs/p2/MetadataRepositoryStub.java
@@ -140,4 +140,9 @@ public class MetadataRepositoryStub implements IMetadataRepository {
 	public void compress(IPool<IInstallableUnit> iuPool) {
 	}
 
+	@Override
+	public boolean removeReferences(Collection<? extends IRepositoryReference> references) {
+		return false;
+	}
+
 }

--- a/org.eclipse.cbi.targetplatform.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.cbi.targetplatform.ui.tests/META-INF/MANIFEST.MF
@@ -33,5 +33,6 @@ Import-Package: org.hamcrest.core,
  org.junit.runner;version="4.5.0",
  org.junit.runners.model;version="4.5.0",
  org.junit.runners;version="4.5.0",
- org.junit;version="4.5.0"
+ org.junit;version="4.5.0",
+ javax.inject
 Automatic-Module-Name: org.eclipse.cbi.targetplatform.ui.tests

--- a/org.eclipse.cbi.targetplatform/.launchers/GenerateTargetPlatformDSL.mwe2.launch
+++ b/org.eclipse.cbi.targetplatform/.launchers/GenerateTargetPlatformDSL.mwe2.launch
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.emf.mwe2.launch.Mwe2LaunchConfigurationType">
+    <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
     <stringAttribute key="org.eclipse.debug.core.ATTR_REFRESH_SCOPE" value="${workspace}"/>
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
         <listEntry value="/org.eclipse.cbi.targetplatform"/>
@@ -12,7 +13,9 @@
     </listAttribute>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_EXCLUDE_TEST_CODE" value="true"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11/"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher"/>
     <stringAttribute key="org.eclipse.jdt.launching.MODULE_NAME" value="org.eclipse.cbi.targetplatform"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="src/main/java/org/eclipse/cbi/targetplatform/GenerateTargetPlatform.mwe2"/>

--- a/org.eclipse.cbi.targetplatform/build.properties
+++ b/org.eclipse.cbi.targetplatform/build.properties
@@ -25,7 +25,6 @@ additional.bundles = org.eclipse.xtext.xbase,\
                      org.eclipse.emf.mwe2.lib,\
                      org.objectweb.asm,\
                      org.apache.commons.logging,\
-                     org.apache.log4j,\
+                     slf4j.api,\
                      com.ibm.icu,\
-                     org.eclipse.emf.ecore.xcore,\
-                     org.eclipse.xtext.generator
+                     org.eclipse.emf.ecore.xcore


### PR DESCRIPTION
- org.eclipse.xtext.generator is gone, the migration was done already
- org.eclipse.xtext.xtext.generator requires slf4j.api now
- MWE2 launch fails when Java 8 is found, requires at least Java 11
- we still require javax.inject
- IMetadataRepository now declares removeReference()