### PR TITLE
fix workspace setup after Eclipse 2024-03 release

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
 
     tools {
         maven 'apache-maven-latest'
-        jdk 'openjdk-jdk11-latest'
+        jdk 'temurin-jdk17-latest'
     }
 
     environment {

--- a/TPD.setup
+++ b/TPD.setup
@@ -13,7 +13,7 @@
     xmlns:setup.targlets="http://www.eclipse.org/oomph/setup/targlets/1.0"
     xmlns:setup.workingsets="http://www.eclipse.org/oomph/setup/workingsets/1.0"
     xmlns:workingsets="http://www.eclipse.org/oomph/workingsets/1.0"
-    xsi:schemaLocation="http://www.eclipse.org/oomph/setup/git/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Git.ecore http://www.eclipse.org/oomph/setup/jdt/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/JDT.ecore http://www.eclipse.org/oomph/setup/launching/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Launching.ecore http://www.eclipse.org/oomph/predicates/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Predicates.ecore http://www.eclipse.org/oomph/setup/projects/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Projects.ecore http://www.eclipse.org/oomph/setup/targlets/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupTarglets.ecore http://www.eclipse.org/oomph/setup/workingsets/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupWorkingSets.ecore http://www.eclipse.org/oomph/workingsets/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/WorkingSets.ecore"
+    xsi:schemaLocation="http://www.eclipse.org/oomph/setup/git/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/Git.ecore http://www.eclipse.org/oomph/setup/jdt/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/JDT.ecore http://www.eclipse.org/oomph/setup/launching/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/Launching.ecore http://www.eclipse.org/oomph/predicates/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/Predicates.ecore http://www.eclipse.org/oomph/setup/projects/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/Projects.ecore http://www.eclipse.org/oomph/setup/targlets/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/SetupTarglets.ecore http://www.eclipse.org/oomph/setup/workingsets/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/SetupWorkingSets.ecore http://www.eclipse.org/oomph/workingsets/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/WorkingSets.ecore"
     name="tpd"
     label="Target Platform Definition DSL">
   <annotation
@@ -68,9 +68,8 @@
   </setupTask>
   <setupTask
       xsi:type="jdt:JRETask"
-      version="JavaSE-11"
-      location="${jre.location-11}"
-      name="JRE for JavaSE-11">
+      version="JavaSE-17"
+      location="${jre.location-17}">
     <description>Define the JRE needed to compile and run the Java projects of ${scope.project.label}</description>
   </setupTask>
   <setupTask

--- a/org.eclipse.cbi.targetplatform.tests/src/main/java/org/eclipse/cbi/targetplatform/tests/stubs/p2/MetadataRepositoryStub.java
+++ b/org.eclipse.cbi.targetplatform.tests/src/main/java/org/eclipse/cbi/targetplatform/tests/stubs/p2/MetadataRepositoryStub.java
@@ -140,4 +140,9 @@ public class MetadataRepositoryStub implements IMetadataRepository {
 	public void compress(IPool<IInstallableUnit> iuPool) {
 	}
 
+	@Override
+	public boolean removeReferences(Collection<? extends IRepositoryReference> references) {
+		return false;
+	}
+
 }

--- a/org.eclipse.cbi.targetplatform.ui.tests/src/main/java/org/eclipse/cbi/targetplatform/ui/tests/TestContentAssist.xtend
+++ b/org.eclipse.cbi.targetplatform.ui.tests/src/main/java/org/eclipse/cbi/targetplatform/ui/tests/TestContentAssist.xtend
@@ -15,9 +15,9 @@
 package org.eclipse.cbi.targetplatform.ui.tests
 
 import com.google.common.collect.ImmutableList
+import com.google.inject.Inject
 import java.net.URI
 import java.util.Locale
-import javax.inject.Inject
 import org.eclipse.cbi.targetplatform.tests.stubs.p2.IQueryResultProvider
 import org.eclipse.cbi.targetplatform.tests.stubs.p2.IUStub
 import org.eclipse.cbi.targetplatform.tests.stubs.p2.MetadataRepositoryManagerStub

--- a/org.eclipse.cbi.targetplatform/.launchers/GenerateTargetPlatformDSL.mwe2.launch
+++ b/org.eclipse.cbi.targetplatform/.launchers/GenerateTargetPlatformDSL.mwe2.launch
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.emf.mwe2.launch.Mwe2LaunchConfigurationType">
+    <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
     <stringAttribute key="org.eclipse.debug.core.ATTR_REFRESH_SCOPE" value="${workspace}"/>
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
         <listEntry value="/org.eclipse.cbi.targetplatform"/>
@@ -12,7 +13,9 @@
     </listAttribute>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_EXCLUDE_TEST_CODE" value="true"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11/"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher"/>
     <stringAttribute key="org.eclipse.jdt.launching.MODULE_NAME" value="org.eclipse.cbi.targetplatform"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="src/main/java/org/eclipse/cbi/targetplatform/GenerateTargetPlatform.mwe2"/>

--- a/org.eclipse.cbi.targetplatform/build.properties
+++ b/org.eclipse.cbi.targetplatform/build.properties
@@ -25,7 +25,6 @@ additional.bundles = org.eclipse.xtext.xbase,\
                      org.eclipse.emf.mwe2.lib,\
                      org.objectweb.asm,\
                      org.apache.commons.logging,\
-                     org.apache.log4j,\
+                     slf4j.api,\
                      com.ibm.icu,\
-                     org.eclipse.emf.ecore.xcore,\
-                     org.eclipse.xtext.generator
+                     org.eclipse.emf.ecore.xcore

--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,8 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <tycho-version>2.7.5</tycho-version>
-    <xtext-version>2.27.0</xtext-version>
+    <tycho-version>4.0.6</tycho-version>
+    <xtext-version>2.34.0</xtext-version>
     <cbi-plugins.version>1.3.4</cbi-plugins.version>
     <os-jvm-flags/>
     <eclipse-repo.url>https://repo.eclipse.org/content/repositories/cbi/</eclipse-repo.url>
@@ -288,7 +288,7 @@
             <artifactId>tycho-packaging-plugin</artifactId>
             <dependencies>
               <dependency>
-                <groupId>org.eclipse.tycho.extras</groupId>
+                <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-buildtimestamp-jgit</artifactId>
                 <version>${tycho-version}</version>
               </dependency>

--- a/promotion/pom.xml
+++ b/promotion/pom.xml
@@ -28,7 +28,7 @@ SPDX-License-Identifier: EPL-2.0
   <packaging>pom</packaging>
 
   <properties>
-    <eclipse.repo>https://download.eclipse.org/releases/2022-12</eclipse.repo>
+    <eclipse.repo>https://download.eclipse.org/releases/latest</eclipse.repo>
     <justj.tools.repo>https://download.eclipse.org/justj/tools/updates/nightly/latest</justj.tools.repo>
     <org.eclipse.download.location.relative>cbi/updates</org.eclipse.download.location.relative>
     <org.eclipse.storage.user>genie.cbi</org.eclipse.storage.user>
@@ -43,11 +43,11 @@ SPDX-License-Identifier: EPL-2.0
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho.extras</groupId>
-        <artifactId>tycho-eclipserun-plugin</artifactId>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-eclipse-plugin</artifactId>
         <version>${tycho-version}</version>
         <configuration>
-          <executionEnvironment>JavaSE-11</executionEnvironment>
+          <executionEnvironment>JavaSE-17</executionEnvironment>
           <dependencies>
             <dependency>
               <artifactId>org.eclipse.justj.p2</artifactId>

--- a/target-platforms/default.target
+++ b/target-platforms/default.target
@@ -1,47 +1,46 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Default (clean build) Target Platform" sequenceNumber="1684912042">
+<target name="Default (clean build) Target Platform" sequenceNumber="1710945266">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.license.feature.group" version="2.0.2.v20181016-2210"/>
       <repository location="https://download.eclipse.org/cbi/updates/license/2.0.2.v20181016-2210"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.xtext.ui.feature.group" version="2.29.0.v20221121-1054"/>
-      <unit id="org.eclipse.xtext.xtext.ui.feature.group" version="2.29.0.v20221121-1054"/>
-      <unit id="org.eclipse.xtext.runtime.feature.group" version="2.29.0.v20221121-1054"/>
-      <unit id="org.eclipse.xtext.testing" version="2.29.0.v20221121-0917"/>
-      <unit id="org.eclipse.xtext.junit4" version="2.29.0.v20221121-0943"/>
-      <unit id="org.eclipse.xtext.xbase.testing" version="2.29.0.v20221121-0924"/>
-      <unit id="org.eclipse.xtext.xbase.junit" version="2.29.0.v20221121-0943"/>
-      <unit id="org.eclipse.xtext.xbase.ui.testing" version="2.29.0.v20221121-0943"/>
-      <unit id="org.eclipse.xtext.generator" version="2.29.0.v20221121-0924"/>
-      <unit id="org.objectweb.asm" version="9.4.0.v20221107-1714"/>
-      <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.29.0"/>
+      <unit id="org.eclipse.xtext.ui.feature.group" version="2.34.0.v20240227-0940"/>
+      <unit id="org.eclipse.xtext.xtext.ui.feature.group" version="2.34.0.v20240227-0940"/>
+      <unit id="org.eclipse.xtext.runtime.feature.group" version="2.34.0.v20240227-0940"/>
+      <unit id="org.eclipse.xtext.testing" version="2.34.0.v20240227-0940"/>
+      <unit id="org.eclipse.xtext.junit4" version="2.34.0.v20240227-0940"/>
+      <unit id="org.eclipse.xtext.xbase.testing" version="2.34.0.v20240227-0940"/>
+      <unit id="org.eclipse.xtext.xbase.junit" version="2.34.0.v20240227-0940"/>
+      <unit id="org.eclipse.xtext.xbase.ui.testing" version="2.34.0.v20240227-0940"/>
+      <unit id="org.objectweb.asm" version="9.6.0"/>
+      <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.34.0"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.pde.junit.runtime" version="3.6.200.v20220523-1051"/>
-      <unit id="org.eclipse.jdt.junit4.runtime" version="1.3.0.v20220609-1843"/>
-      <unit id="org.eclipse.platform.feature.group" version="4.26.0.v20221123-2302"/>
-      <unit id="org.eclipse.pde.core" version="3.16.0.v20221119-0340"/>
-      <unit id="org.eclipse.equinox.p2.core" version="2.9.200.v20220817-1208"/>
-      <unit id="org.eclipse.equinox.p2.repository" version="2.6.300.v20221030-1923"/>
-      <unit id="org.eclipse.equinox.p2.metadata" version="2.6.300.v20220817-1208"/>
-      <unit id="org.eclipse.jdt.launching" version="3.19.800.v20221107-1851"/>
-      <repository location="https://download.eclipse.org/eclipse/updates/4.26"/>
+      <unit id="org.eclipse.pde.junit.runtime" version="3.8.100.v20240130-1723"/>
+      <unit id="org.eclipse.jdt.junit4.runtime" version="1.3.100.v20231214-1952"/>
+      <unit id="org.eclipse.platform.feature.group" version="4.31.0.v20240229-1022"/>
+      <unit id="org.eclipse.pde.core" version="3.18.0.v20240215-1456"/>
+      <unit id="org.eclipse.equinox.p2.core" version="2.11.0.v20240210-1628"/>
+      <unit id="org.eclipse.equinox.p2.repository" version="2.8.100.v20240207-1113"/>
+      <unit id="org.eclipse.equinox.p2.metadata" version="2.9.0.v20240213-1100"/>
+      <unit id="org.eclipse.jdt.launching" version="3.21.100.v20240214-1729"/>
+      <repository location="https://download.eclipse.org/eclipse/updates/4.31"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.emf.ecore.xcore" version="1.23.0.v20221121-1400"/>
-      <unit id="org.eclipse.emf.ecore" version="2.29.0.v20221121-1400"/>
-      <unit id="org.eclipse.emf.ecore.xcore.lib" version="1.6.0.v20210405-0628"/>
-      <repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.32"/>
+      <unit id="org.eclipse.emf.ecore.xcore" version="1.28.0.v20231208-1446"/>
+      <unit id="org.eclipse.emf.ecore" version="2.36.0.v20240203-0859"/>
+      <unit id="org.eclipse.emf.ecore.xcore.lib" version="1.7.0.v20230204-1018"/>
+      <repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.37.0"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.emf.mwe2.launch" version="2.14.0.v20221117-1134"/>
-      <unit id="org.eclipse.emf.mwe.core" version="1.8.0.v20221117-1134"/>
-      <unit id="org.eclipse.emf.mwe2.lib" version="2.14.0.v20221117-1134"/>
-      <repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.14.0"/>
+      <unit id="org.eclipse.emf.mwe2.launch" version="2.17.0.v20240224-1400"/>
+      <unit id="org.eclipse.emf.mwe.core" version="1.11.0.v20240224-1400"/>
+      <unit id="org.eclipse.emf.mwe2.lib" version="2.17.0.v20240224-1400"/>
+      <repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.17.0"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="de.itemis.xtext.antlr.sdk.feature.group" version="2.1.1.v201405091103"/>
@@ -53,9 +52,9 @@
       <repository location="https://xtexttools.libutzki.de/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="com.google.gson" version="2.9.1.v20220915-1632"/>
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20221123021534/repository"/>
+      <unit id="com.google.gson" version="2.10.1"/>
+      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.31.0"/>
     </location>
   </locations>
-  <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+  <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 </target>

--- a/target-platforms/default.tpd
+++ b/target-platforms/default.tpd
@@ -1,20 +1,20 @@
 target "Default (clean build) Target Platform"
 
-include "testing/4.26-2022-12.tpd" with source requirements environment JavaSE-11
+include "testing/4.31-2024-03.tpd" with source requirements environment JavaSE-17
 
-location "https://download.eclipse.org/eclipse/updates/4.26" {
+location "https://download.eclipse.org/eclipse/updates/4.31" {
 	// required to start UI tests in workbench - not a dependency per se
 	org.eclipse.pde.junit.runtime
 	org.eclipse.jdt.junit4.runtime
 }
 
 // Required for xcore source generation
-location "https://download.eclipse.org/modeling/emf/emf/builds/release/2.32" {
+location "https://download.eclipse.org/modeling/emf/emf/builds/release/2.37.0" {
 	org.eclipse.emf.ecore.xcore
 }
 
 // Required for launching mwe2 workflow (main class org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher)
-location "https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.14.0" {
+location "https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.17.0" {
 	org.eclipse.emf.mwe2.launch
 }
 
@@ -29,6 +29,6 @@ location "https://xtexttools.libutzki.de/" {
 	de.libutzki.xtext.semanticmodeloutline.feature.feature.group
 }
 
-location "https://download.eclipse.org/tools/orbit/downloads/drops/R20221123021534/repository" {
+location "https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.31.0" {
 	com.google.gson
 }

--- a/target-platforms/inc/xtext-target.tpd
+++ b/target-platforms/inc/xtext-target.tpd
@@ -4,31 +4,29 @@ location "https://download.eclipse.org/cbi/updates/license/2.0.2.v20181016-2210"
 	org.eclipse.license.feature.group
 }
 
-location "https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.29.0" {
+location "https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.34.0" {
 	// do not depend on org.eclipse.xtext.sdk.feature.group to avoid dependency to draw2d  
 	org.eclipse.xtext.ui.feature.group
 	org.eclipse.xtext.xtext.ui.feature.group
 	org.eclipse.xtext.runtime.feature.group
-	
+
 	org.eclipse.xtext.testing
 	org.eclipse.xtext.junit4
-	
+
 	org.eclipse.xtext.xbase.testing
 	org.eclipse.xtext.xbase.junit
 	org.eclipse.xtext.xbase.ui.testing
-	
-	org.eclipse.xtext.generator
-	
+
 	org.objectweb.asm
 }
 
-location "https://download.eclipse.org/modeling/emf/emf/builds/release/2.32" {
+location "https://download.eclipse.org/modeling/emf/emf/builds/release/2.37.0" {
 	org.eclipse.emf.ecore
 	org.eclipse.emf.ecore.xcore.lib
 }
 
 // required for resolving dependencies of Xtext
-location "https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.14.0" {
+location "https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.17.0" {
 	org.eclipse.emf.mwe.core
 	org.eclipse.emf.mwe2.lib
 }

--- a/target-platforms/testing/4.31-2024-03.tpd
+++ b/target-platforms/testing/4.31-2024-03.tpd
@@ -1,0 +1,19 @@
+target "4.31 Testing Target Platform"
+
+include "../inc/xtext-target.tpd"
+
+with source requirements
+environment JavaSE-17
+
+location "https://download.eclipse.org/eclipse/updates/4.31" {
+	org.eclipse.platform.feature.group
+
+	org.eclipse.pde.core
+
+	org.eclipse.equinox.p2.core
+	org.eclipse.equinox.p2.repository
+	org.eclipse.equinox.p2.metadata
+
+	org.eclipse.jdt.launching
+
+}


### PR DESCRIPTION
- org.eclipse.xtext.generator is gone, the migration was done already
- org.eclipse.xtext.xtext.generator requires slf4j.api now
- MWE2 launch fails when Java 8 is found, requires at least Java 11
- Use com.google.inject.Inject because javax.inject.Inject fails Tycho
- IMetadataRepository now declares removeReference()
- Update Tycho to 4.0.6
- Update promotion to use https://download.eclipse.org/releases/latest
- Update default target platform to 2024-03 and other new release
- Update setup to configure Java 17.