### PR TITLE
fix MWE2 launch after updates regarding Eclipse 2024-03 release

### DIFF
--- a/org.eclipse.cbi.targetplatform/.launchers/GenerateTargetPlatformDSL.mwe2.launch
+++ b/org.eclipse.cbi.targetplatform/.launchers/GenerateTargetPlatformDSL.mwe2.launch
@@ -15,7 +15,7 @@
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_EXCLUDE_TEST_CODE" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
-    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11/"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher"/>
     <stringAttribute key="org.eclipse.jdt.launching.MODULE_NAME" value="org.eclipse.cbi.targetplatform"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="src/main/java/org/eclipse/cbi/targetplatform/GenerateTargetPlatform.mwe2"/>


### PR DESCRIPTION
- MWE2 launch fails when Java 11 is found, requires at least Java 17