### PR TITLE
[#56] resolve all declared version ranges per IU ID

### DIFF
--- a/org.eclipse.cbi.targetplatform-feature/feature.xml
+++ b/org.eclipse.cbi.targetplatform-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.cbi.targetplatform.feature"
       label="%featureName"
-      version="3.0.0.qualifier"
+      version="3.1.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.cbi.targetplatform"
       license-feature="org.eclipse.license"

--- a/org.eclipse.cbi.targetplatform-feature/pom.xml
+++ b/org.eclipse.cbi.targetplatform-feature/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>org.eclipse.cbi.targetplatform-parent</artifactId>
     <groupId>org.eclipse.cbi.targetplatform</groupId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.cbi.targetplatform.feature</artifactId>
   <packaging>eclipse-feature</packaging>

--- a/org.eclipse.cbi.targetplatform-update/pom.xml
+++ b/org.eclipse.cbi.targetplatform-update/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>org.eclipse.cbi.targetplatform-parent</artifactId>
     <groupId>org.eclipse.cbi.targetplatform</groupId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.cbi.targetplatform-update</artifactId>
   <packaging>eclipse-repository</packaging>

--- a/org.eclipse.cbi.targetplatform.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.cbi.targetplatform.ide/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.cbi.targetplatform.ide;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.1.0.qualifier
 Require-Bundle: org.eclipse.cbi.targetplatform.model,
  org.eclipse.cbi.targetplatform,
  org.eclipse.xtext.ide,

--- a/org.eclipse.cbi.targetplatform.ide/pom.xml
+++ b/org.eclipse.cbi.targetplatform.ide/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>org.eclipse.cbi.targetplatform-parent</artifactId>
     <groupId>org.eclipse.cbi.targetplatform</groupId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.cbi.targetplatform.ide</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/org.eclipse.cbi.targetplatform.model/META-INF/MANIFEST.MF
+++ b/org.eclipse.cbi.targetplatform.model/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.cbi.targetplatform.model;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-ClassPath: .
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.ecore;visibility:=reexport,

--- a/org.eclipse.cbi.targetplatform.model/pom.xml
+++ b/org.eclipse.cbi.targetplatform.model/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>org.eclipse.cbi.targetplatform-parent</artifactId>
     <groupId>org.eclipse.cbi.targetplatform</groupId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.cbi.targetplatform.model</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/org.eclipse.cbi.targetplatform.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.cbi.targetplatform.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-SymbolicName: org.eclipse.cbi.targetplatform.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.cbi.targetplatform,

--- a/org.eclipse.cbi.targetplatform.tests/pom.xml
+++ b/org.eclipse.cbi.targetplatform.tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>org.eclipse.cbi.targetplatform-parent</artifactId>
     <groupId>org.eclipse.cbi.targetplatform</groupId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.cbi.targetplatform.tests</artifactId>
   <packaging>eclipse-test-plugin</packaging>

--- a/org.eclipse.cbi.targetplatform.tests/src/main/java/org/eclipse/cbi/targetplatform/tests/TestTargetConversion.xtend
+++ b/org.eclipse.cbi.targetplatform.tests/src/main/java/org/eclipse/cbi/targetplatform/tests/TestTargetConversion.xtend
@@ -332,13 +332,16 @@ class TestTargetConversion {
 			target "TP1"
 			include "tp2.tpd"
 			location "http://download.eclipse.org/tools/orbit/downloads/drops/R20130517111416/repository/" { 
-				com.google.guava
+				com.google.guava // no version, last location (top level): resolve newest version
+				com.google.guava // ignore duplicate
+				com.google.guava;version="[11.0.0,12.0.0)" // redundant override
 			}
 		''', URI.createURI("tmp:/tp1.tpd"), resourceSet)
 		parser.parse('''
 			target "TP2"
 			location "http://download.eclipse.org/tools/orbit/downloads/drops/R20130517111416/repository/" {
-				com.google.guava;version="[11.0.0,12.0.0)"
+				com.google.guava;version="[11.0.0,12.0.0)" // resolve specified version
+				com.google.guava;version="[11.0.0,12.0.0)" // ignore duplicate
 			}
 		''', URI.createURI("tmp:/tp2.tpd"), resourceSet)
 
@@ -362,9 +365,12 @@ class TestTargetConversion {
 		
 		val String[] ids = targetDef.locations.map[resolvedIUs.map[id]].flatten
 		val Version[] versions = targetDef.locations.map[resolvedIUs.map[version]].flatten
-		assertEquals(1, ids.size)
-		assertEquals("com.google.guava", ids.head)
-		assertEquals("12.0.0", versions.head.toString)
+		assertEquals(2, ids.size)
+		assertEquals("com.google.guava", ids.get(0))
+		assertEquals("com.google.guava", ids.get(1))
+		assertEquals(2, versions.size)
+		assertTrue(versions.findFirst[it.toString == "11.0.2"] !== null)
+		assertTrue(versions.findFirst[it.toString == "12.0.0"] !== null)
 	}
 	
 	@Test
@@ -378,13 +384,16 @@ class TestTargetConversion {
 		parser.parse('''
 			target "TP2"
 			location "http://download.eclipse.org/tools/orbit/downloads/drops/R20130517111416/repository/" {
-				com.google.guava;version=[11.0.0,12.0.0)
+				com.google.guava;version=[11.0.0,12.0.0) // resolve specified version
+				com.google.guava;version=[11.0.0,12.0.0) // ignore duplicate
 			}
 		''', URI.createURI("tmp:/tp2.tpd"), resourceSet)
 		parser.parse('''
 			target "TP3"
 			location "http://download.eclipse.org/tools/orbit/downloads/drops/R20130517111416/repository/" {
-				com.google.guava
+				com.google.guava // no version, last location (via includes): resolve newest version
+				com.google.guava // ignore duplicate
+				com.google.guava;version=[11.0.0,12.0.0) // redundant override
 			}
 		''', URI.createURI("tmp:/tp3.tpd"), resourceSet)
 		
@@ -408,9 +417,12 @@ class TestTargetConversion {
 		
 		val String[] ids = targetDef.locations.map[resolvedIUs.map[id]].flatten
 		val Version[] versions = targetDef.locations.map[resolvedIUs.map[version]].flatten
-		assertEquals(1, ids.size)
-		assertEquals("com.google.guava", ids.head)
-		assertEquals("12.0.0", versions.head.toString)
+		assertEquals(2, ids.size)
+		assertEquals("com.google.guava", ids.get(0))
+		assertEquals("com.google.guava", ids.get(1))
+		assertEquals(2, versions.size)
+		assertTrue(versions.findFirst[it.toString == "11.0.2"] !== null)
+		assertTrue(versions.findFirst[it.toString == "12.0.0"] !== null)
 	}
 	
 	@Test
@@ -424,13 +436,15 @@ class TestTargetConversion {
 		parser.parse('''
 			target "TP2"
 			location "http://download.eclipse.org/tools/orbit/downloads/drops/R20130517111416/repository/" {
-				com.google.guava;version=[11.0.0,12.0.0)
+				com.google.guava;version=[11.0.0,12.0.0) // resolve specified version
+				com.google.guava;version=[11.0.0,12.0.0) // ignore duplicate
 			}
 		''', URI.createURI("tmp:/tp2.tpd"), resourceSet)
 		parser.parse('''
 			target "TP3"
 			location "http://download.eclipse.org/tools/orbit/downloads/drops/R20130517111416/repository/" {
-				com.google.guava
+				com.google.guava // no version: is overridden by subsequent location (via includes)
+				com.google.guava // ignore duplicate
 			}
 		''', URI.createURI("tmp:/tp3.tpd"), resourceSet)
 		
@@ -470,13 +484,15 @@ class TestTargetConversion {
 			target "TP2"
 			include "tp3.tpd"
 			location "http://download.eclipse.org/tools/orbit/downloads/drops/R20130517111416/repository/" {
-				com.google.guava;version=[11.0.0,12.0.0)
+				com.google.guava;version=[11.0.0,12.0.0) // resolve specified version
+				com.google.guava;version=[11.0.0,12.0.0) // ignore duplicate
 			}
 		''', URI.createURI("tmp:/tp2.tpd"), resourceSet)
 		parser.parse('''
 			target "TP3"
 			location "http://download.eclipse.org/tools/orbit/downloads/drops/R20130517111416/repository/" {
-				com.google.guava
+				com.google.guava // no version: is overridden by subsequent location (via includes)
+				com.google.guava // ignore duplicate
 			}
 		''', URI.createURI("tmp:/tp3.tpd"), resourceSet)
 		
@@ -516,13 +532,15 @@ class TestTargetConversion {
 			target "TP2"
 			include "tp3.tpd"
 			location "http://download.eclipse.org/tools/orbit/downloads/drops/R20130517111416/repository/" {
-				com.google.guava
+				com.google.guava // no version, last location (via includes): resolve newest version
+				com.google.guava // ignore duplicate
 			}
 		''', URI.createURI("tmp:/tp2.tpd"), resourceSet)
 		parser.parse('''
 			target "TP3"
 			location "http://download.eclipse.org/tools/orbit/downloads/drops/R20130517111416/repository/" {
-				com.google.guava;version=[11.0.0,12.0.0)
+				com.google.guava;version=[11.0.0,12.0.0) // resolve specified version
+				com.google.guava;version=[11.0.0,12.0.0) // ignore duplicate
 			}
 		''', URI.createURI("tmp:/tp3.tpd"), resourceSet)
 		
@@ -546,9 +564,12 @@ class TestTargetConversion {
 		
 		val String[] ids = targetDef.locations.map[resolvedIUs.map[id]].flatten
 		val Version[] versions = targetDef.locations.map[resolvedIUs.map[version]].flatten
-		assertEquals(1, ids.size)
-		assertEquals("com.google.guava", ids.head)
-		assertEquals("12.0.0", versions.head.toString)
+		assertEquals(2, ids.size)
+		assertEquals("com.google.guava", ids.get(0))
+		assertEquals("com.google.guava", ids.get(1))
+		assertEquals(2, versions.size)
+		assertTrue(versions.findFirst[it.toString == "11.0.2"] !== null)
+		assertTrue(versions.findFirst[it.toString == "12.0.0"] !== null)
 	}
 	
 	@Test
@@ -558,10 +579,12 @@ class TestTargetConversion {
 			target "TP1"
 			include "tp2.tpd"
 			location "http://download.eclipse.org/tools/orbit/downloads/drops/R20130517111416/repository/" { 
-				com.google.guava
+				com.google.guava // no version: is overridden by subsequent location
+				com.google.guava // ignore duplicate
 			}
 			location "http://download.eclipse.org/tools/orbit/downloads/drops/R20130517111416/repository/" {
-				com.google.guava;version="[11.0.0,12.0.0)"
+				com.google.guava;version="[11.0.0,12.0.0)" // resolve specified version
+				com.google.guava;version="[11.0.0,12.0.0)" // ignore duplicate
 			}
 		''', URI.createURI("tmp:/tp1.tpd"), resourceSet)
 		
@@ -597,10 +620,12 @@ class TestTargetConversion {
 			target "TP1"
 			include "tp2.tpd"
 			location "http://download.eclipse.org/tools/orbit/downloads/drops/R20130517111416/repository/" {
-				com.google.guava;version="[11.0.0,12.0.0)"
+				com.google.guava;version="[11.0.0,12.0.0)" // resolve specified version
+				com.google.guava;version="[11.0.0,12.0.0)" // ignore duplicate
 			}
 			location "http://download.eclipse.org/tools/orbit/downloads/drops/R20130517111416/repository/" { 
-				com.google.guava
+				com.google.guava // no version, last location: resolve newest version
+				com.google.guava // ignore duplicate
 			}
 		''', URI.createURI("tmp:/tp1.tpd"), resourceSet)
 		
@@ -624,9 +649,12 @@ class TestTargetConversion {
 		
 		val String[] ids = targetDef.locations.map[resolvedIUs.map[id]].flatten
 		val Version[] versions = targetDef.locations.map[resolvedIUs.map[version]].flatten
-		assertEquals(1, ids.size)
-		assertEquals("com.google.guava", ids.head)
-		assertEquals("12.0.0", versions.head.toString)
+		assertEquals(2, ids.size)
+		assertEquals("com.google.guava", ids.get(0))
+		assertEquals("com.google.guava", ids.get(1))
+		assertEquals(2, versions.size)
+		assertTrue(versions.findFirst[it.toString == "11.0.2"] !== null)
+		assertTrue(versions.findFirst[it.toString == "12.0.0"] !== null)
 	}
 	
 	@Test
@@ -636,8 +664,10 @@ class TestTargetConversion {
 			target "TP1"
 			include "tp2.tpd"
 			location "http://download.eclipse.org/tools/orbit/downloads/drops/R20130517111416/repository/" {
-				com.google.guava;version="[11.0.0,12.0.0)"
-				com.google.guava
+				com.google.guava;version="[11.0.0,12.0.0)" // resolve specified version
+				com.google.guava;version="[11.0.0,12.0.0)" // ignore duplicate
+				com.google.guava // no version, not first declaration in location: ignored
+				com.google.guava // ignore duplicate
 			}
 		''', URI.createURI("tmp:/tp1.tpd"), resourceSet)
 		
@@ -673,8 +703,10 @@ class TestTargetConversion {
 			target "TP1"
 			include "tp2.tpd"
 			location "http://download.eclipse.org/tools/orbit/downloads/drops/R20130517111416/repository/" {
-				com.google.guava
-				com.google.guava;version="[11.0.0,12.0.0)"
+				com.google.guava // no version, first declaration in location: resolve newest version
+				com.google.guava;version="[11.0.0,12.0.0)" // resolve specified version
+				com.google.guava;version="[11.0.0,12.0.0)" // ignore duplicate
+				com.google.guava // ignore duplicate
 			}
 		''', URI.createURI("tmp:/tp1.tpd"), resourceSet)
 		
@@ -698,9 +730,12 @@ class TestTargetConversion {
 		
 		val String[] ids = targetDef.locations.map[resolvedIUs.map[id]].flatten
 		val Version[] versions = targetDef.locations.map[resolvedIUs.map[version]].flatten
-		assertEquals(1, ids.size)
-		assertEquals("com.google.guava", ids.head)
-		assertEquals("12.0.0", versions.head.toString)
+		assertEquals(2, ids.size)
+		assertEquals("com.google.guava", ids.get(0))
+		assertEquals("com.google.guava", ids.get(1))
+		assertEquals(2, versions.size)
+		assertTrue(versions.findFirst[it.toString == "11.0.2"] !== null)
+		assertTrue(versions.findFirst[it.toString == "12.0.0"] !== null)
 	}
 	
 	@Test

--- a/org.eclipse.cbi.targetplatform.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.cbi.targetplatform.ui.tests/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.cbi.targetplatform.ui.tests;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.cbi.targetplatform.ui.tests;x-internal=true

--- a/org.eclipse.cbi.targetplatform.ui.tests/pom.xml
+++ b/org.eclipse.cbi.targetplatform.ui.tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>org.eclipse.cbi.targetplatform-parent</artifactId>
     <groupId>org.eclipse.cbi.targetplatform</groupId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.cbi.targetplatform.ui.tests</artifactId>
   <packaging>eclipse-test-plugin</packaging>

--- a/org.eclipse.cbi.targetplatform.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.cbi.targetplatform.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-SymbolicName: org.eclipse.cbi.targetplatform.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.cbi.targetplatform,

--- a/org.eclipse.cbi.targetplatform.ui/pom.xml
+++ b/org.eclipse.cbi.targetplatform.ui/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>org.eclipse.cbi.targetplatform-parent</artifactId>
     <groupId>org.eclipse.cbi.targetplatform</groupId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.cbi.targetplatform.ui</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/org.eclipse.cbi.targetplatform/META-INF/MANIFEST.MF
+++ b/org.eclipse.cbi.targetplatform/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-SymbolicName: org.eclipse.cbi.targetplatform;singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.cbi.targetplatform.model,

--- a/org.eclipse.cbi.targetplatform/pom.xml
+++ b/org.eclipse.cbi.targetplatform/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>org.eclipse.cbi.targetplatform-parent</artifactId>
     <groupId>org.eclipse.cbi.targetplatform</groupId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.cbi.targetplatform</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/org.eclipse.cbi.targetplatform/src/main/java/org/eclipse/cbi/targetplatform/resolved/ResolvedTargetPlatform.java
+++ b/org.eclipse.cbi.targetplatform/src/main/java/org/eclipse/cbi/targetplatform/resolved/ResolvedTargetPlatform.java
@@ -139,12 +139,16 @@ public class ResolvedTargetPlatform {
 		List<UnresolvedIU> ius = Lists.newArrayList();
 		Set<String> ids = Sets.newHashSet();
 		List<Location> list = locationIndex.get(locationUri);
-		for (Location location : list) {
+		for (Location location : list) { // in reverse order of declaration: overrides seen first
 			EList<IU> iuList = location.getIus();
-			for (IU iu : iuList) {
-				if (!ids.contains(iu.getID())) {
-					ids.add(iu.getID());
-					ius.add(new UnresolvedIU(iu.getID(), Strings.emptyToNull(iu.getVersion())));
+			for (IU iu : iuList) { // in order of declaration
+				String idv = iu.getID() + ":" + Strings.nullToEmpty(iu.getVersion());
+				if (!ids.contains(idv)) { // neither duplicates (same location), nor redundant overrides (across locations)
+					if (iu.getVersion() != null || !ids.contains(iu.getID())) { // can override the unversioned only
+						ids.add(idv);
+						ids.add(iu.getID());
+						ius.add(new UnresolvedIU(iu.getID(), Strings.emptyToNull(iu.getVersion())));
+					}
 				}
 			}
 		}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.eclipse.cbi.targetplatform</groupId>
   <artifactId>org.eclipse.cbi.targetplatform-parent</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <licenses>
@@ -276,7 +276,7 @@
                 <artifact>
                   <groupId>org.eclipse.cbi.targetplatform</groupId>
                   <artifactId>org.eclipse.cbi.targetplatform-parent</artifactId>
-                  <version>3.0.0-SNAPSHOT</version>
+                  <version>3.1.0-SNAPSHOT</version>
                   <classifier>target-platforms/default</classifier>
                 </artifact>
               </target>
@@ -317,7 +317,7 @@
                 <artifact>
                   <groupId>org.eclipse.cbi.targetplatform</groupId>
                   <artifactId>org.eclipse.cbi.targetplatform-parent</artifactId>
-                  <version>3.0.0-SNAPSHOT</version>
+                  <version>3.1.0-SNAPSHOT</version>
                   <classifier>target-platforms/testing/4.8-photon</classifier>
                 </artifact>
               </target>
@@ -342,7 +342,7 @@
                 <artifact>
                   <groupId>org.eclipse.cbi.targetplatform</groupId>
                   <artifactId>org.eclipse.cbi.targetplatform-parent</artifactId>
-                  <version>3.0.0-SNAPSHOT</version>
+                  <version>3.1.0-SNAPSHOT</version>
                   <classifier>target-platforms/testing/4.7-oxygen</classifier>
                 </artifact>
               </target>
@@ -367,7 +367,7 @@
                 <artifact>
                   <groupId>org.eclipse.cbi.targetplatform</groupId>
                   <artifactId>org.eclipse.cbi.targetplatform-parent</artifactId>
-                  <version>3.0.0-SNAPSHOT</version>
+                  <version>3.1.0-SNAPSHOT</version>
                   <classifier>target-platforms/testing/4.6-neon</classifier>
                 </artifact>
               </target>
@@ -392,7 +392,7 @@
                 <artifact>
                   <groupId>org.eclipse.cbi.targetplatform</groupId>
                   <artifactId>org.eclipse.cbi.targetplatform-parent</artifactId>
-                  <version>3.0.0-SNAPSHOT</version>
+                  <version>3.1.0-SNAPSHOT</version>
                   <classifier>target-platforms/testing/4.5-mars</classifier>
                 </artifact>
               </target>
@@ -417,7 +417,7 @@
                 <artifact>
                   <groupId>org.eclipse.cbi.targetplatform</groupId>
                   <artifactId>org.eclipse.cbi.targetplatform-parent</artifactId>
-                  <version>3.0.0-SNAPSHOT</version>
+                  <version>3.1.0-SNAPSHOT</version>
                   <classifier>target-platforms/testing/4.4-luna</classifier>
                 </artifact>
               </target>

--- a/promotion/pom.xml
+++ b/promotion/pom.xml
@@ -18,13 +18,13 @@ SPDX-License-Identifier: EPL-2.0
   <parent>
     <groupId>org.eclipse.cbi.targetplatform</groupId>
     <artifactId>org.eclipse.cbi.targetplatform-parent</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.eclipse.cbi</groupId>
   <artifactId>org.eclipse.cbi.targetplatform.promote</artifactId>
-  <version>3.0.0-SNAPSHOTT</version>
+  <version>3.1.0-SNAPSHOTT</version>
   <packaging>pom</packaging>
 
   <properties>


### PR DESCRIPTION
Regarding version overrides:
- a specified version range always is fulfilled
- within the same location declaration:
  - first declaration resolves to most recent as declared
  - subsequent unversioned declaration resolves to any former one
- across subsequent location declarations:
  - earlier unversioned declaration is overridden
  - later unversioned declaration resolves to most recent available