### PR TITLE
Use org.eclipse.xtext.testing.validation.ValidatorTester

### DIFF
--- a/org.eclipse.cbi.targetplatform.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.cbi.targetplatform.tests/META-INF/MANIFEST.MF
@@ -23,7 +23,6 @@ Require-Bundle: org.eclipse.cbi.targetplatform,
  org.eclipse.xtext.ui,
  org.eclipse.cbi.targetplatform.model,
  org.eclipse.xtext.testing,
- org.eclipse.xtext.junit4,
  org.eclipse.xtext.xbase.testing,
  org.eclipse.xtext.xbase.junit
 Import-Package: org.apache.log4j,

--- a/org.eclipse.cbi.targetplatform.tests/src/main/java/org/eclipse/cbi/targetplatform/tests/TestValidation.xtend
+++ b/org.eclipse.cbi.targetplatform.tests/src/main/java/org/eclipse/cbi/targetplatform/tests/TestValidation.xtend
@@ -29,11 +29,11 @@ import org.eclipse.cbi.targetplatform.validation.TargetPlatformValidator
 import org.eclipse.emf.common.util.Diagnostic
 import org.eclipse.emf.common.util.URI
 import org.eclipse.xtext.Constants
-import org.eclipse.xtext.junit4.validation.ValidatorTester
 import org.eclipse.xtext.resource.XtextResourceSet
 import org.eclipse.xtext.testing.InjectWith
 import org.eclipse.xtext.testing.XtextRunner
 import org.eclipse.xtext.testing.util.ParseHelper
+import org.eclipse.xtext.testing.validation.ValidatorTester
 import org.eclipse.xtext.validation.AbstractValidationDiagnostic
 import org.eclipse.xtext.validation.EValidatorRegistrar
 import org.eclipse.xtext.validation.FeatureBasedDiagnostic


### PR DESCRIPTION
Stop using org.eclipse.xtext.junit4.validation.ValidatorTester which is deprecated.