### PR TITLE
Build and setup updates

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
 
   tools {
     maven 'apache-maven-latest'
-    jdk 'temurin-jdk17-latest'
+    jdk 'temurin-jdk21-latest'
   }
 
   environment {
@@ -62,8 +62,6 @@ ARCHIVE=${params.ARCHIVE}
 """.trim()
           echo description
           currentBuild.description = description.replace("\n", "<br/>")
-          env.PROMOTE = params.PROMOTE
-          env.BUILD_TYPE = params.BUILD_TYPE
         }
        }
     }

--- a/TPD.setup
+++ b/TPD.setup
@@ -68,8 +68,8 @@
   </setupTask>
   <setupTask
       xsi:type="jdt:JRETask"
-      version="JavaSE-17"
-      location="${jre.location-17}">
+      version="JavaSE-21"
+      location="${jre.location-21}">
     <description>Define the JRE needed to compile and run the Java projects of ${scope.project.label}</description>
   </setupTask>
   <setupTask
@@ -377,7 +377,7 @@
   <setupTask
       xsi:type="setup:StringSubstitutionTask"
       name="maven.build.java.home"
-      value="${jre.location-11}">
+      value="${jre.location-21}">
     <description>The location used to specify JAVA_HOME in the External Tools Configurations.</description>
   </setupTask>
   <setupTask

--- a/TPDConfiguration.setup
+++ b/TPDConfiguration.setup
@@ -35,6 +35,11 @@
       name="tdp.workspace"
       label="Target Platform Definition DSL Workspace">
     <setupTask
+        xsi:type="setup:VariableTask"
+        name="eclipse.target.platform"
+        value="${eclipse.target.platform.latest}"
+        storageURI="scope://Workspace"/>
+    <setupTask
         xsi:type="setup:CompoundTask"
         name="User Preferences">
       <setupTask

--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.version.ignore>.*[a-zA-Z]+.*</maven.version.ignore>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <tycho-version>4.0.8</tycho-version>
-    <xtext-version>2.36.0</xtext-version>
+    <tycho-version>4.0.10</tycho-version>
+    <xtext-version>2.37.0</xtext-version>
     <cbi-plugins.version>1.5.0</cbi-plugins.version>
     <os-jvm-flags/>
     <eclipse-repo.url>https://repo.eclipse.org/content/repositories/cbi/</eclipse-repo.url>

--- a/promotion/pom.xml
+++ b/promotion/pom.xml
@@ -47,7 +47,7 @@ SPDX-License-Identifier: EPL-2.0
         <artifactId>tycho-eclipse-plugin</artifactId>
         <version>${tycho-version}</version>
         <configuration>
-          <executionEnvironment>JavaSE-17</executionEnvironment>
+          <executionEnvironment>JavaSE-21</executionEnvironment>
           <dependencies>
             <dependency>
               <artifactId>org.eclipse.justj.p2</artifactId>


### PR DESCRIPTION
- Use JDK 21 for the build.
- Update to xtext-version 2.37.0.
- Update to Tycho 4.0.10.
- Improve setup configuration to specify the latest target platform.
- Configure Java 21 for the JRE setup.